### PR TITLE
v0.5.0: 4-activity modality + audit gate + guided loop enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,16 @@ build/
 .env
 bench/
 codex_bench/
+
+# Agent install outputs — generated per-user by `hyperresearch install`.
+# These files contain absolute paths resolved to the installing user's
+# Python environment. NEVER commit them. The authoritative versions live
+# in src/hyperresearch/skills/ (skills) and src/hyperresearch/core/hooks.py
+# (agent templates).
+.claude/
+CLAUDE.md
+AGENTS.md
+GEMINI.md
+
+# Per-vault research output
+research/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/banner.png" alt="HYPERRESEARCH" width="700">
 </p>
 
-<h3 align="center">Ultra deep, persistent web research for AI coding agents</h3>
+<h3 align="center">Deep, structured, adversarially-audited research for AI coding agents</h3>
 
 <p align="center">
   <a href="https://pypi.org/project/hyperresearch/"><img src="https://img.shields.io/pypi/v/hyperresearch" alt="PyPI version"></a>
@@ -13,50 +13,206 @@
 
 ---
 
-Your AI agent searches the web, finds great sources, synthesizes an answer — then the session ends and everything is gone. Next time, it starts from zero.
+Your AI agent searches the web, skims sources, writes an answer that sounds good, and ships it. There's no scaffold, no audit, no source-vs-source comparison, no provenance, no way to know if it actually engaged with the strongest counter-position. Next session, the work is gone.
 
-**Hyperresearch makes research persist.** Every source your agent finds is fetched with a real headless browser, saved as searchable markdown, and indexed into a knowledge base that compounds across sessions. Hyperresearch can follow maps of links to digest paths of information that current agent web searching isn't capable of.
+**Hyperresearch makes research disciplined and persistent.** Every fetched source becomes a markdown note in a Zettelkasten knowledge base. Every research session follows a 14-step protocol with four hard checkpoints. Two adversarial auditor subagents tear the draft apart against the user's verbatim prompt before save is allowed. The user's prompt is gospel — pasted into the scaffold's first section, re-read at every step, machine-checked at the gate.
 
 ```bash
 pip install hyperresearch
 hyperresearch install
 ```
 
+That's it. In Claude Code: type `/research <topic>`.
+
+---
+
+## The architecture
+
+### One dispatcher, four cognitive activities
+
+Hyperresearch routes every research request by what the output needs to **do**, not what the subject **is**. A query about a fictional franchise can be `collect` (per-character enumeration), `synthesize` (a thesis about meaning), `compare` (this work vs another), or `forecast` (will this sequel succeed). Subject doesn't decide; activity does.
+
+```mermaid
+graph LR
+    P[User Prompt] --> D{Dispatcher}
+    D -->|"what exists"| C[collect<br/>enumerative coverage]
+    D -->|"what it means"| S[synthesize<br/>defended thesis]
+    D -->|"which is best"| CMP[compare<br/>committed pick]
+    D -->|"what will happen"| F[forecast<br/>committed prediction]
+
+    C --> R[Final Report<br/>+ Audit Trail]
+    S --> R
+    CMP --> R
+    F --> R
+
+    style D fill:#1e293b,stroke:#475569,color:#fff
+    style C fill:#0f4c5c,stroke:#3b82f6,color:#fff
+    style S fill:#0f4c5c,stroke:#3b82f6,color:#fff
+    style CMP fill:#0f4c5c,stroke:#3b82f6,color:#fff
+    style F fill:#0f4c5c,stroke:#3b82f6,color:#fff
+    style R fill:#166534,stroke:#22c55e,color:#fff
+```
+
+Each modality file encodes only its substance differences (source strategy, writing rules, conformance checks). The shared 14-step protocol — discovery, fetch, curation, scaffold, comparisons, draft, audit, synthesis — lives in one dispatcher. Tight, factored, no duplication.
+
+### The context flow — verbatim prompt is gospel
+
+Every step re-encounters the user's original prompt. It gets pasted verbatim into the scaffold's first section, the auditor reads it at every audit, the save gate machine-checks it. No paraphrasing, no drift.
+
+```mermaid
+flowchart TB
+    P[📥 User Prompt] -->|verbatim, never paraphrased| CLS[1. Classify activity<br/>+ extract deliverables]
+    CLS --> SRC[2. Source discovery<br/>+ adversarial round]
+    SRC --> FET[3. Seed fetch<br/>3-5 high-signal URLs]
+    FET --> LOOP{4. Guided reading loop}
+    LOOP -->|analyst proposes targets| FET2[Fetch with --suggested-by<br/>builds rooted provenance graph]
+    FET2 --> LOOP
+    LOOP -->|coverage complete| CK1[✓ Checkpoint 1<br/>voice diversity + dissent]
+
+    CK1 --> CUR[5-6. Curate every source<br/>tier + content_type + analyst extract]
+    CUR --> CK2[✓ Checkpoint 2<br/>provenance rooted-tree<br/>analyst coverage]
+
+    CK2 --> SCF[7. Build scaffold<br/>📌 verbatim prompt as §1]
+    SCF --> CMP[8. Comparisons note<br/>3-5 source-vs-source disagreements]
+    CMP --> CK3[✓ Checkpoint 3<br/>scaffold-prompt lint<br/>artifacts present]
+
+    CK3 --> DRF[9. Write draft<br/>against the scaffold]
+    DRF --> GAP[10. Gap analysis<br/>+ adversarial search]
+    GAP --> AUD[11. Adversarial audit<br/>2 modes, persisted to JSON]
+    AUD --> CK4[✓ Checkpoint 4<br/>audit-gate self-cert detection]
+
+    CK4 --> SYN[12. Opinionated synthesis]
+    SYN --> SAVE[13-14. Save synthesis note<br/>blocked until audit-gate passes]
+
+    style P fill:#7c2d12,stroke:#ea580c,color:#fff
+    style SCF fill:#7c2d12,stroke:#ea580c,color:#fff
+    style AUD fill:#581c87,stroke:#a855f7,color:#fff
+    style CK1 fill:#166534,stroke:#22c55e,color:#fff
+    style CK2 fill:#166534,stroke:#22c55e,color:#fff
+    style CK3 fill:#166534,stroke:#22c55e,color:#fff
+    style CK4 fill:#166534,stroke:#22c55e,color:#fff
+    style SAVE fill:#166534,stroke:#22c55e,color:#fff
+```
+
+The four checkpoints are hard gates. **Checkpoint 3** runs `scaffold-prompt` lint that machine-checks the verbatim prompt is in the scaffold's first section. **Checkpoint 4** runs `audit-gate` lint that re-runs the underlying lint rules referenced by every CRITICAL audit finding — if a finding was marked "fixed" but the underlying rule still fails, the gate emits a `SELF-CERTIFICATION VIOLATION` and blocks save. The agent cannot ship a draft that grades its own homework.
+
+### The subagent triad
+
+Hyperresearch ships three registered Claude Code subagents, each picked for its job:
+
+```mermaid
+graph TB
+    M[🤖 Main Agent<br/>your Claude Code session]
+
+    M -.spawns.-> F[🌐 hyperresearch-fetcher<br/><b>Haiku</b><br/>cheap URL fetching]
+    M -.spawns.-> A[📖 hyperresearch-analyst<br/><b>Sonnet</b><br/>guided reading + extraction]
+    M -.spawns.-> AU[🔍 hyperresearch-auditor<br/><b>Opus</b><br/>adversarial review]
+
+    F -->|fetched note| V[(Vault<br/>SQLite + markdown)]
+    A -->|extract note + next_targets| V
+    A -.proposes URLs.-> M
+    AU -->|findings JSON| V
+    AU -->|pass/fail| M
+
+    style M fill:#1e293b,stroke:#475569,color:#fff
+    style F fill:#0c4a6e,stroke:#0ea5e9,color:#fff
+    style A fill:#0e7490,stroke:#06b6d4,color:#fff
+    style AU fill:#581c87,stroke:#a855f7,color:#fff
+    style V fill:#166534,stroke:#22c55e,color:#fff
+```
+
+| Agent | Model | Job | Why this model |
+|---|---|---|---|
+| **hyperresearch-fetcher** | Haiku | Fetches a URL via crawl4ai, persists the note. Mechanical, fast, parallel. | URL fetching is mechanical. Haiku is 10× cheaper. |
+| **hyperresearch-analyst** | Sonnet | Reads one source with the research goal in hand, writes a focused extract, proposes 2-5 next targets for the guided loop. | Reasoning about what's relevant + what to read next is real work. Sonnet hits the cost/quality sweet spot for hundreds of source reads per session. |
+| **hyperresearch-auditor** | Opus | Runs in two modes (`comprehensiveness` + `conformance`) against the verbatim prompt. Independently re-extracts entities, runs lint rules, persists findings to JSON. | Adversarial review over a long document against multiple criteria is critical reasoning. Worth Opus's ceiling. |
+
+The **guided reading loop** is the engine of deep research: seed-fetch 3-5 URLs → spawn an analyst on each → analysts propose `next_targets` → main agent fetches those WITH `--suggested-by` provenance → loop. Every fetched source carries a wiki-link breadcrumb back to the source that recommended it, so the research graph is a rooted, traceable tree. The provenance lint rule enforces this structurally.
+
+### The audit-gate self-certification detector
+
+The most important quality guarantee in v0.5.0. Two modes of the auditor run sequentially, each persisting findings to `research/audit_findings.json`. The agent applies fixes and marks each CRITICAL `fixed_at: <timestamp>`. The save gate then doesn't trust those marks blindly:
+
+```mermaid
+flowchart LR
+    A[Auditor finds<br/>CRITICAL: provenance broken] --> B[Agent applies fix]
+    B --> C[Agent marks<br/>fixed_at: timestamp]
+    C --> D{audit-gate lint}
+    D -->|extracts keyword<br/>'provenance'| E[Re-run<br/>provenance lint rule]
+    E -->|still has errors| F[❌ SELF-CERTIFICATION VIOLATION<br/>save blocked]
+    E -->|now clean| G[✓ Save proceeds]
+
+    style F fill:#7f1d1d,stroke:#ef4444,color:#fff
+    style G fill:#166534,stroke:#22c55e,color:#fff
+    style D fill:#581c87,stroke:#a855f7,color:#fff
+```
+
+Every CRITICAL with a `fixed_at` timestamp gets its underlying lint rule re-run in the same lint pass. If the rule still returns errors, the agent's "fix" was bookkeeping not substance — and the synthesis save is blocked until the actual vault state matches the claim. The 60+ keyword map covers `provenance`, `analyst-coverage`, `scaffold-prompt`, `workflow`, `uncurated` and natural-language variants. Findings that don't map to any rule emit an advisory warning ("not machine-verified") so the human reviewer sees which findings rest on agent self-report.
+
+---
+
 ## What people use it for
 
-- **In-depth topic research** — "Research the latest advances in state space models" → agent fetches 20+ papers, docs, and blog posts, follows citations to primary sources, builds a linked knowledge graph
-- **News tracking over time** — run research sessions weekly on a topic, each session builds on what's already collected, nothing gets re-fetched
-- **State-of-the-art surveys** — "What's the current SOTA for speech recognition?" → agent goes down rabbit holes, collects benchmarks, papers, and implementations
-- **Competitive analysis** — scrape company pages, LinkedIn profiles, product docs, news articles into a persistent, searchable corpus
-- **Due diligence** — aggregate everything about a person, company, or technology from across the web with authenticated crawling (LinkedIn, Twitter, paywalled sites)
+- **In-depth topic research** — "What does the literature say about ion-trap quantum scaling?" → 25+ academic sources, 8+ analyst extracts, dissenting voices represented, full provenance graph
+- **Comparative evaluation** — "TigerBeetle vs Postgres vs FoundationDB for write-heavy workloads" → per-entity coverage, comparison matrix, committed recommendation, mandatory critical voice on the market leader
+- **Forecasting + strategy** — "Will US inflation stay above 3% through 2026?" → ground-truth statistics + institutional analysis + named contrarians, probability language not hedge language, explicit time horizon
+- **Interpretive analysis** — "What does Blood Meridian's violence mean?" → primary text + critical tradition + dissenting reading, every paragraph fuses fact with interpretive claim
+- **Enumerative coverage** — "For each Napoleonic marshal, cover key campaigns and fate" → per-entity treatment with the 4 fields, no silent downgrades from "each" to "representative examples"
+- **Persistent knowledge base** — every source ever fetched stays searchable. Future sessions check the vault before searching the web. Knowledge compounds.
 
-## How it works
+---
 
-1. **You ask your agent to research something**
-2. **Agent searches the web** — multiple queries, different angles
-3. **Fetches every source** with a real headless browser (crawl4ai) — JS rendering, bot detection bypass, login-gated content
-4. **Saves each page** as a searchable markdown note with tags, summary, and source tracking
-5. **Follows links** to primary sources — the paper, not the blog post about the paper
-6. **Auto-links related notes** with `[[wiki-links]]` across the knowledge graph
-7. **Synthesizes findings** into a summary note linking all sources
-8. **Next session** — agent checks the KB before searching the web. Knowledge compounds.
+## What you get out of the box
 
-```
-your-repo/
-  .hyperresearch/        # Config + SQLite FTS5 index (rebuildable)
-  research/
-    notes/               # Markdown notes — the source of truth
-    index/               # Auto-generated wiki pages
-  CLAUDE.md              # Agent docs (auto-injected)
+```bash
+pip install hyperresearch
+hyperresearch install
 ```
 
-## Works with every major agent
+That single sequence:
 
-`hyperresearch install` hooks into your agent in one step:
+1. Initializes a v6 SQLite vault with FTS5 search at `.hyperresearch/`
+2. Auto-installs Chromium for crawl4ai if missing
+3. Writes `CLAUDE.md` with the protocol overview
+4. Installs the `/research` skill (dispatcher + 4 modality files) to `.claude/skills/hyperresearch/`
+5. Registers all 3 subagents (fetcher, analyst, auditor) to `.claude/agents/`
+6. Wires PreToolUse hooks into `.claude/settings.json`
+7. Sets crawl4ai as the default web provider
+
+You're ready. Type `/research <anything>` in Claude Code.
+
+### What's enforced
+
+- **Verbatim prompt as gospel** — machine-checked via `scaffold-prompt` lint rule
+- **Rooted-tree provenance graph** — `--suggested-by` chain must form an actual tree from seeds; isolated breadcrumbs are flagged
+- **Analyst coverage** — at least 1 extract per 3 sources (no silent skipping)
+- **Adversarial dissent** — Checkpoint 1 requires at least one source explicitly dissents from the dominant view
+- **Audit gate self-cert detection** — CRITICAL findings marked fixed must actually be fixed; bookkeeping fixes get caught
+- **Save blocked** until audit-gate passes — synthesis cannot ship if any CRITICAL is unresolved
+- **Schema integrity** — `tier` and `content_type` are SQLite CHECK-constrained vocabularies; corrupted frontmatter cannot poison the index
+- **PDF + raw artifact persistence** — fetched PDFs land in `research/raw/` and the `raw_file` frontmatter field survives all re-serializations
+
+### Key features
+
+- **Real headless browser** — crawl4ai runs local Chromium. JS rendering, bot detection bypass, SPA support. Not an HTTP fetch.
+- **Native PDF extraction** — fetched PDFs go through pymupdf, full text extracted, raw file persisted
+- **Authenticated crawling** — log into LinkedIn / Twitter / paywalled news once via `hyperresearch setup`; the profile auto-applies on every fetch
+- **Junk detection** — captchas, cookie walls, login redirects, binary garbage, error pages all caught and rejected
+- **Fetch resilience** — when a high-priority source fails, the agent tries alternative URLs (preprint server, author page, institutional repo), then `--visible` browser, then a summary as fallback. Failures get documented; nothing silently disappears.
+- **MCP server** — 13 tools (read + write) for Claude Desktop, Cursor, or any MCP client
+- **Note lifecycle** — `draft → review → evergreen → stale → deprecated → archive`
+- **Knowledge graph** — `[[wiki-links]]`, backlinks, hub detection, auto-linking
+- **FTS5 search** — instant full-text search with BM25 ranking across thousands of notes
+
+---
+
+## Hooks for every major agent
+
+`hyperresearch install` wires into your agent in one step:
 
 | Platform | Hook | Trigger |
 |----------|------|---------|
-| **Claude Code** | `.claude/settings.json` + `/research` skill | Before WebSearch, WebFetch |
+| **Claude Code** | `.claude/settings.json` + `/research` skill + 3 subagents | Before WebSearch, WebFetch |
 | **Codex** | `.codex/hooks.json` | Before Bash |
 | **Cursor** | `.cursor/rules/hyperresearch.mdc` | Always-apply rule |
 | **Gemini CLI** | `.gemini/settings.json` | Before tool calls |
@@ -65,49 +221,41 @@ your-repo/
 hyperresearch install --platform all    # Hook every platform at once
 ```
 
-## Key features
-
-- **Real headless browser** — crawl4ai runs local Chromium. Handles JavaScript, bypasses bot detection, renders SPAs. Not a simple HTTP fetch.
-- **Native PDF extraction** — fetches PDFs directly, extracts full text with pymupdf, saves raw files to `research/raw/`. Academic papers, whitepapers, reports — all first-class citizens.
-- **Authenticated crawling** — log into LinkedIn, Twitter, paywalled news. Your sessions persist across fetches.
-- **Agent-driven curation** — fetcher subagents read each source, write real summaries, add meaningful tags, and flag junk. No keyword-matching shortcuts.
-- **Junk detection** — Cloudflare captchas, error pages, cookie walls, binary garbage, login redirects all caught and rejected before saving.
-- **Multi-round deep research** — the agent does multiple rounds of search → fetch → follow links, with a source checkpoint that forces breadth before synthesis.
-- **Gap analysis + adversarial audit** — after drafting, the agent re-reads the original query to find gaps, then spawns two auditor subagents (comprehensiveness + logic) to tear the draft apart. Runs twice.
-- **Cheap parallel fetching** — ships a Haiku-powered subagent that fetches, summarizes, and quality-checks URLs in parallel for pennies. Spawn 10-20 per round.
-- **Scholarly API guidance** — agent docs encourage use of arXiv, Semantic Scholar, CrossRef, and PubMed APIs for academic topics.
-- **`/research` skill** — scripted deep research workflow. Clarifies ambiguous requests, searches broadly, fetches aggressively, follows rabbit holes, audits, synthesizes.
-- **Smart SPA wait** — polls DOM stability instead of fixed delays. Fast pages finish instantly, SPAs get up to 10 seconds.
-- **FTS5 search** — instant full-text search across thousands of notes with BM25 ranking
-- **Knowledge graph** — `[[wiki-links]]`, backlinks, hub detection, auto-linking
-- **MCP server** — 13 tools (read + write) for Claude Desktop, Cursor, or any MCP client
-- **Note lifecycle** — draft → review → evergreen → stale → deprecated → archive
+---
 
 ## Commands
 
 ```bash
-# Research
-hyperresearch fetch <url> --tag t -j           # Fetch a URL into the KB
-hyperresearch fetch-batch <urls...> -j         # Fetch many URLs at once
-hyperresearch research "topic" --max 5 -j      # Full pipeline: search → fetch → link → synthesize
+# Research workflow
+hyperresearch fetch <url> --tag t -j                       # Fetch a URL into the KB
+hyperresearch fetch <url> --suggested-by <id> -j           # Track provenance during the guided loop
+hyperresearch fetch <url> --visible -j                     # Bypass bot detection with a visible browser
 
-# Search
-hyperresearch search "query" -j                # Full-text search
-hyperresearch search "query" --max-tokens 8000 # Stay within context budget
-hyperresearch note show <id> -j                # Read a note
+# Search + read
+hyperresearch search "query" -j                            # Full-text search
+hyperresearch search "query" --tier ground_truth -j        # Filter by epistemic tier
+hyperresearch search "query" --content-type paper -j       # Filter by artifact kind
+hyperresearch note show <id> -j                            # Read a note
+hyperresearch note show <id> --meta -j                     # Read frontmatter only (cheap triage)
+hyperresearch note list --status draft -j                  # List notes with summaries
 
 # Knowledge graph
-hyperresearch link --auto -j                   # Auto-link related notes
-hyperresearch graph hubs -j                    # Most-connected notes
-hyperresearch graph backlinks <id> -j          # What links to this note
+hyperresearch link --auto -j                               # Auto-link related notes
+hyperresearch graph hubs -j                                # Most-connected notes
+hyperresearch graph backlinks <id> -j                      # What links to this note
 
-# Manage
-hyperresearch sources list -j                  # Every URL ever fetched
-hyperresearch lint -j                          # Health check
-hyperresearch repair -j                        # Fix links, rebuild indexes
+# Health checks
+hyperresearch lint -j                                      # Run all rules
+hyperresearch lint --rule scaffold-prompt -j               # Verbatim prompt gospel rule
+hyperresearch lint --rule provenance -j                    # Rooted-tree breadcrumb chain
+hyperresearch lint --rule audit-gate -j                    # Self-certification detector
+hyperresearch lint --rule analyst-coverage -j              # Extract:source ratio
+hyperresearch repair -j                                    # Fix links, rebuild indexes
 ```
 
 Every command returns `{"ok": true, "data": {...}}` with `-j`.
+
+---
 
 ## Authenticated crawling
 
@@ -126,22 +274,33 @@ profile = "research"
 
 LinkedIn, Twitter, Facebook, Instagram, and TikTok automatically use a visible browser to avoid session kills.
 
+---
+
 ## Philosophy
 
-- **No LLM calls.** Hyperresearch stores, indexes, and searches. Your agent is the LLM.
-- **Markdown is truth.** Notes are plain files. SQLite is a rebuildable cache.
-- **Over-collect, then prune.** Fetch aggressively. Deprecate what you don't need.
-- **Check before you fetch.** Hooks kill redundant searches across sessions.
-- **Raw content is king.** Save the original with formatting, not a rewritten summary.
+- **Process is load-bearing.** A draft without a scaffold, comparisons, audit findings, and a clean provenance graph is unfinished — regardless of how good the prose reads.
+- **The user's prompt is the only authority.** Activity classification, source strategy, writing constraints all serve the prompt. Substance rules never override what the user actually asked for.
+- **No LLM calls inside the tool.** Hyperresearch stores, indexes, lints, and orchestrates. Your agent is the LLM.
+- **Markdown is truth, SQLite is cache.** Notes are plain files. Delete the DB; `hyperresearch sync` rebuilds it.
+- **Audit findings are artifacts, not just outputs.** They persist to JSON, get verified by lint rules, and gate the save. Self-certification is structurally prevented.
+- **Deeper-not-broader.** v0.5.0 prefers 15 well-extracted sources over 50 skim-fetched ones. The protocol enforces analyst coverage, not source count.
+
+---
 
 ## Requirements
 
 - Python 3.11+
+- Claude Code (or Codex / Cursor / Gemini CLI) with API access
+- Anthropic API key with access to Opus, Sonnet, and Haiku (for the subagent triad)
 - Windows, macOS, Linux
+
+---
 
 ## License
 
 [MIT](LICENSE)
+
+---
 
 ## Star History
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hyperresearch"
-version = "0.4.0"
+version = "0.5.0"
 description = "Agent-driven research knowledge base. Browse, collect, and synthesize web sources into a searchable wiki."
 readme = "README.md"
 license = "MIT"

--- a/src/hyperresearch/__init__.py
+++ b/src/hyperresearch/__init__.py
@@ -1,3 +1,3 @@
 """Hyperresearch — agent-driven research knowledge base."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/hyperresearch/cli/fetch.py
+++ b/src/hyperresearch/cli/fetch.py
@@ -439,23 +439,37 @@ def fetch(
     conn.commit()
 
     # Detect the race: if the committed row's note_id != ours, another
-    # fetch won the race. Clean up our orphan .md file and return the
-    # winner's note_id so the caller can treat this as an idempotent no-op.
+    # fetch won the race. Clean up our orphan .md file (and raw artifact,
+    # if any) and return the winner's note_id so the caller can treat
+    # this as an idempotent no-op.
     winner_row = conn.execute(
         "SELECT note_id FROM sources WHERE url = ?", (url,)
     ).fetchone()
     if winner_row and winner_row["note_id"] != note_id:
         winning_note_id = winner_row["note_id"]
-        # Our write lost the race. Unlink the orphan file and re-sync.
+        # Our write lost the race. Unlink the orphan .md file.
         if note_path.exists():
             try:
                 note_path.unlink()
             except OSError:
                 pass
-            plan2 = compute_sync_plan(vault)
-            if plan2.to_delete:
-                execute_sync(vault, plan2)
+        # Also unlink the raw file we wrote earlier — the winner already
+        # has its own raw file under raw/<winner-id>.<ext>. Without this,
+        # the orphaned-raw-files lint flags raw/<our-id>.<ext> on the
+        # next run and disk leaks accumulate.
+        if raw_file_path:
+            orphan_raw = vault.root / "research" / raw_file_path
+            if orphan_raw.exists():
+                try:
+                    orphan_raw.unlink()
+                except OSError:
+                    pass
+        # Re-sync to drop the orphan note row from the DB.
+        plan2 = compute_sync_plan(vault)
+        if plan2.to_delete:
+            execute_sync(vault, plan2)
         note_id = winning_note_id
+        raw_file_path = None  # we no longer own a raw artifact for this fetch
         winner_path_row = conn.execute(
             "SELECT path FROM notes WHERE id = ?", (winning_note_id,)
         ).fetchone()

--- a/src/hyperresearch/cli/fetch.py
+++ b/src/hyperresearch/cli/fetch.py
@@ -30,6 +30,178 @@ SKIP_URL_PATTERNS = (
 )
 
 
+def _append_suggested_by_to_existing(
+    vault_root: Path,
+    note_id: str,
+    suggested_by: list[str],
+    reason: str | None,
+) -> int:
+    """Append `*Suggested by [[src]] — reason*` breadcrumb lines to an existing note.
+
+    Idempotent: if a breadcrumb for a given source id already exists anywhere
+    in the body, it is not re-added. Returns the number of new breadcrumbs
+    actually added.
+    """
+    # Find the note file — scan research/notes/ for `<note-id>.md` or walk subdirs
+    from hyperresearch.core.frontmatter import parse_frontmatter, serialize_frontmatter
+
+    note_path = None
+    for candidate in vault_root.rglob(f"{note_id}.md"):
+        # Require it to be under a notes directory so we don't match index files
+        if "notes" in candidate.parts:
+            note_path = candidate
+            break
+    if note_path is None:
+        return 0
+
+    text = note_path.read_text(encoding="utf-8-sig")
+    meta, body = parse_frontmatter(text)
+
+    reason_suffix = f" — {reason}" if reason else ""
+    added = 0
+    new_lines = []
+    for src_id in suggested_by:
+        src_clean = src_id.strip()
+        if not src_clean:
+            continue
+        # Skip if a breadcrumb for this source id already exists in the body
+        existing_marker = f"[[{src_clean}]]"
+        if existing_marker in body:
+            continue
+        new_lines.append(f"*Suggested by [[{src_clean}]]{reason_suffix}*")
+        added += 1
+
+    if added == 0:
+        return 0
+
+    # Prepend the new breadcrumb lines to the body
+    breadcrumb_block = "\n".join(new_lines) + "\n\n"
+    new_body = breadcrumb_block + body
+    new_text = serialize_frontmatter(meta) + "\n" + new_body
+    note_path.write_text(new_text, encoding="utf-8")
+    return added
+
+
+def _detect_tier(url: str, content_type: str) -> str:
+    """Guess the epistemic tier from URL + content_type. Returns a Tier value.
+
+    This is a coarse first pass. The curation-time agent is expected to refine
+    (e.g. a medium.com post could be practitioner if it's by a named engineer,
+    or commentary if it's a generic explainer — only reading can tell).
+
+    Defaults prioritize reducing the agent's curation load: URLs with strong
+    signal get a non-unknown default so the agent only needs to verify, not
+    classify from scratch.
+    """
+    domain = urlparse(url).netloc.lower()
+
+    # Ground truth: official primary sources — filings, specs, policy text, datasets
+    if domain.endswith(".gov") or ".gov." in domain or domain.endswith(".gov.uk") or domain.endswith(".europa.eu"):
+        return "ground_truth"
+    if content_type == "policy":
+        return "ground_truth"
+    if content_type == "dataset":
+        return "ground_truth"
+    if content_type == "docs":
+        # Official documentation IS the ground truth for a product/standard
+        return "ground_truth"
+    if content_type == "code":
+        # Source code, README, and repo metadata are ground truth for a tool
+        return "ground_truth"
+
+    # Institutional: peer-reviewed scholarship, canonical reference works
+    if content_type == "paper":
+        # Default to institutional; agent may upgrade to ground_truth if the
+        # paper reports original data or downgrade to commentary for derivatives
+        return "institutional"
+    if "wikipedia.org" in domain or "britannica.com" in domain:
+        return "institutional"
+
+    # Practitioner: forums, community threads, hands-on content
+    if content_type == "forum":
+        return "practitioner"
+    if content_type == "review":
+        return "practitioner"
+
+    # Commentary: news articles, op-eds, blog posts without known authority
+    if content_type == "article":
+        return "commentary"
+    if content_type == "blog":
+        return "commentary"
+    if content_type == "transcript":
+        # Could be institutional (conference keynote) or commentary (podcast)
+        # — agent must decide. Start at commentary; promote during curation.
+        return "commentary"
+
+    return "unknown"
+
+
+def _detect_content_type(url: str, raw_content_type: str | None = None) -> str:
+    """Guess the artifact kind from URL + MIME. Returns a ContentType value or 'unknown'.
+
+    This is a coarse first pass. The creation-time agent is expected to refine
+    during curation if the URL/MIME heuristic is wrong (e.g. a medium.com URL
+    could be blog OR article).
+    """
+    if raw_content_type and "pdf" in raw_content_type.lower():
+        return "paper"
+    u = url.lower()
+    domain = urlparse(url).netloc.lower()
+    path = urlparse(url).path.lower()
+
+    # Papers: arxiv, doi, direct PDFs, openreview, ssrn, biorxiv, pubmed
+    if any(d in domain for d in ("arxiv.org", "doi.org", "openreview.net", "ssrn.com", "biorxiv.org", "medrxiv.org", "pubmed.ncbi.nlm.nih.gov", "ncbi.nlm.nih.gov/pmc", "semanticscholar.org", "openalex.org")):
+        return "paper"
+    if path.endswith(".pdf"):
+        return "paper"
+
+    # Code: github, gitlab, bitbucket, pypi
+    if any(d in domain for d in ("github.com", "gitlab.com", "bitbucket.org", "pypi.org", "crates.io", "npmjs.com")):
+        return "code"
+
+    # Dataset portals that happen to live on .gov domains must win first
+    if domain in ("data.gov", "data.gov.uk") or domain.startswith("data.") and (domain.endswith(".gov") or domain.endswith(".gov.uk") or domain.endswith(".europa.eu")):
+        return "dataset"
+
+    # Policy: gov domains, EU, regulator sites
+    if domain.endswith(".gov") or ".gov." in domain or domain.endswith(".gov.uk") or domain.endswith(".europa.eu") or "regulations.gov" in domain:
+        return "policy"
+
+    # Docs: common documentation platforms, docs.* subdomains, /docs paths
+    if any(d in domain for d in ("readthedocs.io", "readthedocs.org", "docs.rs", "developer.mozilla.org")):
+        return "docs"
+    if domain.startswith("docs.") or domain.startswith("documentation.") or ".readthedocs." in domain:
+        return "docs"
+    if "/docs/" in path or path.endswith("/docs") or "/documentation/" in path or "/api/reference" in path or "/reference/" in path:
+        return "docs"
+
+    # Forum / community
+    if any(d in domain for d in ("reddit.com", "news.ycombinator.com", "stackoverflow.com", "stackexchange.com", "lobste.rs", "lemmy.", "discourse.")):
+        return "forum"
+
+    # Blog platforms
+    if any(d in domain for d in ("medium.com", "substack.com", "dev.to", "hashnode.com", "hashnode.dev", "blogspot.com", "wordpress.com", "ghost.io")):
+        return "blog"
+
+    # Transcripts / video
+    if any(d in domain for d in ("youtube.com", "youtu.be", "vimeo.com")):
+        return "transcript"
+
+    # Reference articles
+    if "wikipedia.org" in domain or "wikimedia.org" in domain or "britannica.com" in domain:
+        return "article"
+
+    # Datasets
+    if any(d in domain for d in ("kaggle.com", "data.gov", "data.world", "zenodo.org", "figshare.com")):
+        return "dataset"
+
+    # News / magazine default
+    if any(d in domain for d in ("nytimes.com", "wsj.com", "ft.com", "bloomberg.com", "reuters.com", "bbc.com", "theatlantic.com", "newyorker.com", "economist.com")):
+        return "article"
+
+    return "unknown"
+
+
 @app.command("fetch")
 def fetch(
     url: str = typer.Argument(..., help="URL to fetch and save as a note"),
@@ -39,6 +211,16 @@ def fetch(
     provider_name: str | None = typer.Option(None, "--provider", help="Web provider override"),
     save_assets: bool = typer.Option(False, "--save-assets", "-a", help="Download images and screenshot"),
     visible: bool = typer.Option(False, "--visible", "-V", help="Run browser visibly (for stubborn auth sites)"),
+    suggested_by: list[str] = typer.Option(
+        [],
+        "--suggested-by",
+        help="Source note ID(s) that suggested this URL. Prepends a 'Suggested by [[note-id]]' breadcrumb to the new note's body, which the link extractor picks up as a wiki-link so the fetched note appears in the source's backlinks. Repeat for multiple sources.",
+    ),
+    suggested_by_reason: str | None = typer.Option(
+        None,
+        "--suggested-by-reason",
+        help="One-line justification for why the suggesting source named this URL. Appears next to the [[source-id]] breadcrumb.",
+    ),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON output"),
 ) -> None:
     """Fetch a URL and save its content as a research note."""
@@ -63,6 +245,38 @@ def fetch(
     existing = conn.execute("SELECT note_id FROM sources WHERE url = ?", (url,)).fetchone()
     if existing:
         note_id = existing["note_id"]
+        # Graceful duplicate handling for the guided reading loop:
+        # if the caller passed --suggested-by, append the breadcrumb to the
+        # existing note instead of erroring out. This lets the main agent
+        # build up provenance on already-fetched URLs without needing to
+        # check for dupes first.
+        if suggested_by:
+            added = _append_suggested_by_to_existing(
+                vault.root, note_id, suggested_by, suggested_by_reason
+            )
+            # Re-sync so the new wiki-link gets picked up by the link extractor
+            plan = compute_sync_plan(vault)
+            if plan.to_update:
+                execute_sync(vault, plan)
+
+            data = {
+                "note_id": note_id,
+                "url": url,
+                "duplicate": True,
+                "backlinks_added": added,
+                "message": (
+                    f"URL already fetched; added {added} backlink(s) to existing note"
+                    if added
+                    else "URL already fetched; breadcrumb(s) already present"
+                ),
+            }
+            if json_output:
+                output(success(data, vault=str(vault.root)), json_mode=True)
+            else:
+                console.print(f"[yellow]Already fetched:[/] {url} → note '{note_id}'")
+                console.print(f"  added {added} backlink(s) to existing note")
+            return
+
         if json_output:
             output(
                 error(f"URL already fetched as note '{note_id}'", "DUPLICATE_URL"),
@@ -130,6 +344,8 @@ def fetch(
     note_title = title or result.title or urlparse(url).path.split("/")[-1] or "Untitled"
     domain = result.domain
 
+    detected_content_type = _detect_content_type(url, result.raw_content_type)
+    detected_tier = _detect_tier(url, detected_content_type)
     extra_meta = {
         "source": url,
         "source_domain": domain,
@@ -139,14 +355,33 @@ def fetch(
     if result.metadata.get("author"):
         extra_meta["author"] = result.metadata["author"]
 
+    # Build body with backlink breadcrumb if this fetch was suggested by another note.
+    # Prepending `*Suggested by [[source-id]] — reason*` lines creates wiki-links the
+    # normal link extractor will pick up, so the new note automatically appears in
+    # graph backlinks of its suggester(s). Zero schema change needed.
+    body_content = result.content
+    if suggested_by:
+        breadcrumb_lines = []
+        reason_suffix = f" — {suggested_by_reason}" if suggested_by_reason else ""
+        for src_id in suggested_by:
+            src_id_clean = src_id.strip()
+            if not src_id_clean:
+                continue
+            breadcrumb_lines.append(f"*Suggested by [[{src_id_clean}]]{reason_suffix}*")
+        if breadcrumb_lines:
+            breadcrumb = "\n".join(breadcrumb_lines) + "\n\n"
+            body_content = breadcrumb + body_content
+
     note_path = write_note(
         vault.notes_dir,
         title=note_title,
-        body=result.content,
+        body=body_content,
         tags=tags,
         status="draft",
         source=url,
         parent=parent,
+        tier=detected_tier,
+        content_type=detected_content_type,
         extra_frontmatter=extra_meta,
     )
 
@@ -172,18 +407,17 @@ def fetch(
     # Note: tagging and summarization is the agent's job, not an automatic process.
     # The agent reads the fetched content and writes meaningful summaries and tags.
 
-    # Add raw_file reference to frontmatter AFTER enrich (enrich rewrites frontmatter)
+    # Persist raw_file reference on the note via NoteMeta — this guarantees the
+    # field survives any future re-serialization (repair, note update, etc.).
+    # The text-injection approach used previously was silently dropped by
+    # NoteMeta.model_config = {"extra": "ignore"} on the next parse.
     if raw_file_path:
+        from hyperresearch.core.frontmatter import parse_frontmatter, render_note
         note_text = note_path.read_text(encoding="utf-8")
-        if note_text.startswith("---") and "raw_file:" not in note_text:
-            end_idx = note_text.find("---", 3)
-            if end_idx != -1:
-                note_text = (
-                    note_text[:end_idx]
-                    + f"raw_file: {raw_file_path}\n"
-                    + note_text[end_idx:]
-                )
-                note_path.write_text(note_text, encoding="utf-8")
+        meta, body = parse_frontmatter(note_text)
+        if meta.raw_file != raw_file_path:
+            meta.raw_file = raw_file_path
+            note_path.write_text(render_note(meta, body), encoding="utf-8")
 
     # Sync first so the note exists in the notes table (needed for FK on sources/assets)
     note_id = note_path.stem
@@ -191,14 +425,43 @@ def fetch(
     if plan.to_add or plan.to_update:
         execute_sync(vault, plan)
 
-    # Record source in DB
+    # Record source in DB. Use INSERT OR IGNORE to survive a duplicate-URL
+    # race: two parallel fetches on the same URL both pass the earlier
+    # duplicate-check SELECT, both try to INSERT, and without IGNORE the
+    # second crashes with IntegrityError leaving a stray .md file and
+    # notes row but no sources row. With IGNORE the second INSERT is a
+    # no-op and we detect the race by re-selecting the row afterward.
     content_hash = hashlib.sha256(result.content.encode("utf-8")).hexdigest()[:16]
     conn.execute(
-        """INSERT INTO sources (url, note_id, domain, fetched_at, provider, content_hash)
+        """INSERT OR IGNORE INTO sources (url, note_id, domain, fetched_at, provider, content_hash)
            VALUES (?, ?, ?, ?, ?, ?)""",
         (url, note_id, domain, result.fetched_at.isoformat(), prov.name, content_hash),
     )
     conn.commit()
+
+    # Detect the race: if the committed row's note_id != ours, another
+    # fetch won the race. Clean up our orphan .md file and return the
+    # winner's note_id so the caller can treat this as an idempotent no-op.
+    winner_row = conn.execute(
+        "SELECT note_id FROM sources WHERE url = ?", (url,)
+    ).fetchone()
+    if winner_row and winner_row["note_id"] != note_id:
+        winning_note_id = winner_row["note_id"]
+        # Our write lost the race. Unlink the orphan file and re-sync.
+        if note_path.exists():
+            try:
+                note_path.unlink()
+            except OSError:
+                pass
+            plan2 = compute_sync_plan(vault)
+            if plan2.to_delete:
+                execute_sync(vault, plan2)
+        note_id = winning_note_id
+        winner_path_row = conn.execute(
+            "SELECT path FROM notes WHERE id = ?", (winning_note_id,)
+        ).fetchone()
+        if winner_path_row:
+            note_path = vault.root / winner_path_row["path"]
 
     # Save assets (screenshot + images) — only when requested
     saved_assets: list[dict] = []

--- a/src/hyperresearch/cli/fetch.py
+++ b/src/hyperresearch/cli/fetch.py
@@ -145,7 +145,6 @@ def _detect_content_type(url: str, raw_content_type: str | None = None) -> str:
     """
     if raw_content_type and "pdf" in raw_content_type.lower():
         return "paper"
-    u = url.lower()
     domain = urlparse(url).netloc.lower()
     path = urlparse(url).path.lower()
 
@@ -160,7 +159,7 @@ def _detect_content_type(url: str, raw_content_type: str | None = None) -> str:
         return "code"
 
     # Dataset portals that happen to live on .gov domains must win first
-    if domain in ("data.gov", "data.gov.uk") or domain.startswith("data.") and (domain.endswith(".gov") or domain.endswith(".gov.uk") or domain.endswith(".europa.eu")):
+    if domain in ("data.gov", "data.gov.uk") or (domain.startswith("data.") and (domain.endswith(".gov") or domain.endswith(".gov.uk") or domain.endswith(".europa.eu"))):
         return "dataset"
 
     # Policy: gov domains, EU, regulator sites

--- a/src/hyperresearch/cli/lint.py
+++ b/src/hyperresearch/cli/lint.py
@@ -15,6 +15,13 @@ RULES = {
     "missing-title": "Notes without a title",
     "missing-tags": "Notes without any tags",
     "missing-summary": "Notes without a summary",
+    "uncurated": "Non-draft notes without tier or content_type classification",
+    "workflow": "Draft or synthesis notes missing paired scaffold/comparison notes",
+    "scaffold-prompt": "Scaffold notes missing the verbatim user prompt as first section (gospel rule)",
+    "audit-gate": "Unresolved CRITICAL findings in research/audit_findings.json block synthesis save",
+    "provenance": "Source notes with no --suggested-by breadcrumb chain (data-flow chain broken)",
+    "analyst-coverage": "Fetched sources without paired extract notes (analyst skipped most sources)",
+    "orphaned-raw-files": "Files in research/raw/ with no matching note (disk leak from old note rm)",
     "singleton-tags": "Tags used by only one note",
     "broken-links": "Wiki-links that don't resolve",
     "orphaned-notes": "Notes with no inbound or outbound links",
@@ -46,6 +53,12 @@ def lint(
     issues: list[dict] = []
 
     rules_to_run = [rule] if rule else list(RULES.keys())
+
+    # Map from audit-gate CRITICAL finding id -> lint rule name that should be
+    # re-run to verify the fix actually landed. Populated inside the audit-gate
+    # block and consumed at the end of lint() for self-certification detection.
+    # Key words in the finding description are mapped to lint rule names.
+    audit_gate_guards: list[dict] = []  # [{"critical_id", "rule", "description"}]
 
     if "missing-title" in rules_to_run:
         for row in conn.execute("SELECT id, path FROM notes WHERE title = '' OR title = 'Untitled'"):
@@ -83,6 +96,641 @@ def lint(
                 "note_id": row["id"],
                 "note_path": row["path"],
                 "message": "Note has no summary. Add one for better search and listings.",
+            })
+
+    if "audit-gate" in rules_to_run:
+        # Block synthesis save unless BOTH:
+        #   (a) at least one `conformance` audit run exists in
+        #       research/audit_findings.json, AND
+        #   (b) every CRITICAL finding in the most recent conformance run has
+        #       a non-null `fixed_at` timestamp (applied or explicitly resolved).
+        #
+        # Additionally: surface IMPORTANT findings as info-severity issues so
+        # the agent sees them in the pre-save lint output. They don't block
+        # save, but they do nudge the agent to review them before committing.
+        #
+        # Missing file = no audit has run yet. Gate is OPEN in that case so
+        # early-stage lint runs don't spam errors. But once the file exists,
+        # a missing conformance run is itself an error — the protocol demands
+        # both modes, not just comprehensiveness.
+        import json as _json
+        audit_path = vault.root / "research" / "audit_findings.json"
+        if audit_path.exists():
+            try:
+                audit_data = _json.loads(audit_path.read_text(encoding="utf-8"))
+            except (OSError, _json.JSONDecodeError) as exc:
+                issues.append({
+                    "rule": "audit-gate",
+                    "severity": "error",
+                    "note_id": "<vault>",
+                    "message": (
+                        f"research/audit_findings.json exists but is malformed "
+                        f"({type(exc).__name__}). Delete or fix it, then re-run "
+                        f"the adversarial audit."
+                    ),
+                })
+                audit_data = None
+
+            if isinstance(audit_data, dict):
+                runs = audit_data.get("runs", [])
+                conformance_runs = [r for r in runs if r.get("mode") == "conformance"]
+                comprehensiveness_runs = [r for r in runs if r.get("mode") == "comprehensiveness"]
+
+                # Check (a): a conformance run must exist once any audit has happened.
+                if not conformance_runs:
+                    if comprehensiveness_runs:
+                        issues.append({
+                            "rule": "audit-gate",
+                            "severity": "error",
+                            "note_id": "<vault>",
+                            "message": (
+                                f"research/audit_findings.json has "
+                                f"{len(comprehensiveness_runs)} comprehensiveness run(s) but ZERO "
+                                f"conformance runs. Step 11 mandates BOTH modes in parallel. "
+                                f"Spawn hyperresearch-auditor with mode=conformance and wait for "
+                                f"it to append its findings to audit_findings.json before saving "
+                                f"the synthesis."
+                            ),
+                        })
+                    # No runs at all = early stage. Gate stays open.
+                else:
+                    # Check (b): no unresolved CRITICALs in the newest conformance run.
+                    conformance_runs.sort(key=lambda r: r.get("timestamp", ""))
+                    latest = conformance_runs[-1]
+                    latest_status = latest.get("status", "unknown")
+                    criticals = latest.get("criticals") or []
+                    unresolved = [c for c in criticals if not c.get("fixed_at")]
+
+                    if unresolved:
+                        issues.append({
+                            "rule": "audit-gate",
+                            "severity": "error",
+                            "note_id": "<vault>",
+                            "message": (
+                                f"Most recent conformance audit has "
+                                f"{len(unresolved)} unresolved CRITICAL finding(s): "
+                                + "; ".join(
+                                    f"[{c.get('id','?')}] {c.get('description','?')[:80]}"
+                                    for c in unresolved[:5]
+                                )
+                                + ". Apply the fixes in research/notes/final_report.md, "
+                                + "mark each finding with `fixed_at: <ISO>` in "
+                                + "research/audit_findings.json, and re-run the conformance "
+                                + "auditor to verify."
+                            ),
+                        })
+                    elif latest_status == "failed":
+                        issues.append({
+                            "rule": "audit-gate",
+                            "severity": "error",
+                            "note_id": "<vault>",
+                            "message": (
+                                f"Most recent conformance audit returned status=failed. "
+                                f"Investigate the findings and re-run the auditor."
+                            ),
+                        })
+
+                # Surface IMPORTANT findings from EITHER mode's newest run. Info
+                # severity = advisory; does not block save, but the agent sees
+                # them in the save-gate lint output and can choose to patch.
+                for mode_runs, mode_label in (
+                    (conformance_runs, "conformance"),
+                    (comprehensiveness_runs, "comprehensiveness"),
+                ):
+                    if not mode_runs:
+                        continue
+                    mode_runs.sort(key=lambda r: r.get("timestamp", ""))
+                    latest_run = mode_runs[-1]
+                    important = latest_run.get("important") or []
+                    unresolved_important = [i for i in important if not i.get("fixed_at")]
+                    if unresolved_important:
+                        issues.append({
+                            "rule": "audit-gate",
+                            "severity": "info",
+                            "note_id": "<vault>",
+                            "message": (
+                                f"{len(unresolved_important)} unresolved IMPORTANT finding(s) in "
+                                f"the latest {mode_label} audit (advisory, does not block save): "
+                                + "; ".join(
+                                    f"[{i.get('id','?')}] {i.get('description','?')[:80]}"
+                                    for i in unresolved_important[:5]
+                                )
+                                + ". Mark `fixed_at` on each after patching the draft."
+                            ),
+                        })
+
+                # Build guard-rule map: for each CRITICAL with fixed_at set,
+                # extract the implied lint rule from keywords in its description
+                # and queue that rule for verification. This is how audit-gate
+                # detects self-certification (CRITICAL marked fixed but the
+                # underlying lint rule still fails).
+                #
+                # The keyword list covers the natural-language variations we
+                # see in real auditor outputs across modalities. Keep these
+                # broad — false matches are fine (they cause a re-check
+                # which passes harmlessly); missing a match is the failure
+                # mode we're guarding against.
+                _KW_TO_RULE = [
+                    # scaffold-prompt (verbatim prompt gospel rule)
+                    ("scaffold-prompt", "scaffold-prompt"),
+                    ("scaffold_prompt", "scaffold-prompt"),
+                    ("scaffold_extraction_gap", "scaffold-prompt"),
+                    ("scaffold extraction gap", "scaffold-prompt"),
+                    ("verbatim prompt", "scaffold-prompt"),
+                    ("verbatim_prompt", "scaffold-prompt"),
+                    ("gospel rule", "scaffold-prompt"),
+                    ("user prompt missing", "scaffold-prompt"),
+
+                    # analyst-coverage (extract notes per source)
+                    ("analyst-coverage", "analyst-coverage"),
+                    ("analyst coverage", "analyst-coverage"),
+                    ("analyst_coverage", "analyst-coverage"),
+                    ("extract coverage", "analyst-coverage"),
+                    ("extract ratio", "analyst-coverage"),
+                    ("extract notes", "analyst-coverage"),
+                    ("fetch:extract", "analyst-coverage"),
+                    ("analyst skipped", "analyst-coverage"),
+                    ("no extract", "analyst-coverage"),
+
+                    # provenance (bouncing reading loop + --suggested-by chain)
+                    ("provenance", "provenance"),
+                    ("suggested-by", "provenance"),
+                    ("suggested_by", "provenance"),
+                    ("suggested by", "provenance"),
+                    ("bouncing reading loop", "provenance"),
+                    ("bouncing loop", "provenance"),
+                    ("guided reading loop", "provenance"),
+                    ("guided loop", "provenance"),
+                    ("reading loop", "provenance"),
+                    ("breadcrumb", "provenance"),
+                    ("data-flow chain", "provenance"),
+                    ("data flow chain", "provenance"),
+                    ("data-flow broken", "provenance"),
+                    ("rabbit-hole", "provenance"),
+                    ("rabbit hole", "provenance"),
+
+                    # workflow (scaffold + comparisons + extract artifacts exist)
+                    ("workflow", "workflow"),
+                    ("missing scaffold", "workflow"),
+                    ("missing comparison", "workflow"),
+                    ("missing comparisons", "workflow"),
+                    ("paired scaffold", "workflow"),
+                    ("no scaffold note", "workflow"),
+                    ("no comparison note", "workflow"),
+                    ("step 7 skipped", "workflow"),
+                    ("step 8 skipped", "workflow"),
+
+                    # uncurated (tier + content_type + summary metadata)
+                    ("uncurated", "uncurated"),
+                    ("tier metadata", "uncurated"),
+                    ("content_type", "uncurated"),
+                    ("content type", "uncurated"),
+                    ("tier/content_type", "uncurated"),
+                    ("tier and content_type", "uncurated"),
+                    ("classification missing", "uncurated"),
+                    ("metadata missing", "uncurated"),
+                    ("missing tier", "uncurated"),
+                    ("missing summary", "uncurated"),
+                ]
+                for mode_runs in (conformance_runs, comprehensiveness_runs):
+                    if not mode_runs:
+                        continue
+                    # We already sorted conformance_runs above; sort comprehensiveness
+                    # now too so we pick the newest run of each mode.
+                    mode_runs_sorted = sorted(mode_runs, key=lambda r: r.get("timestamp", ""))
+                    latest_run = mode_runs_sorted[-1]
+                    for c in (latest_run.get("criticals") or []):
+                        if not c.get("fixed_at"):
+                            continue  # unresolved criticals already emitted above
+                        desc = (str(c.get("description", "")) + " " +
+                                str(c.get("id", ""))).lower()
+                        matched = None
+                        for kw, rule_name in _KW_TO_RULE:
+                            if kw in desc:
+                                matched = rule_name
+                                break
+                        if matched:
+                            audit_gate_guards.append({
+                                "critical_id": c.get("id", "?"),
+                                "rule": matched,
+                                "description": c.get("description", "")[:120],
+                            })
+                            # Ensure the guard rule runs so we can check its
+                            # issues in post-processing.
+                            if matched not in rules_to_run:
+                                rules_to_run.append(matched)
+                        else:
+                            # CRITICAL marked fixed_at but no known lint rule
+                            # maps to its description. The fix is trust-only
+                            # — we cannot machine-verify it. Surface a warning
+                            # so the user knows this finding was not validated.
+                            issues.append({
+                                "rule": "audit-gate",
+                                "severity": "warning",
+                                "note_id": "<vault>",
+                                "message": (
+                                    f"CRITICAL [{c.get('id','?')}] was marked `fixed_at` but "
+                                    f"its description doesn't map to any known lint rule: "
+                                    f"'{(c.get('description','') or '')[:100]}'. The fix is "
+                                    f"agent-self-reported and not machine-verified. Review the "
+                                    f"draft manually to confirm the issue was actually addressed."
+                                ),
+                            })
+
+    if "scaffold-prompt" in rules_to_run:
+        # Enforce the gospel rule: every scaffold-tagged note must open with
+        # the user's verbatim prompt as its first section. This is the single
+        # machine-checkable invariant that protects the dispatcher's
+        # "user prompt is gospel" commitment. Without this check, scaffolds
+        # can drift — an agent writes a `## Thesis` opening, never pastes the
+        # verbatim prompt, and every downstream step that re-reads the
+        # scaffold (audit, draft, comparisons) loses its anchor.
+        import re as _re
+        _header_re = _re.compile(
+            r"^\s*##\s+User\s+Prompt\s*\(\s*VERBATIM.*gospel\s*\)",
+            _re.IGNORECASE,
+        )
+        for row in conn.execute("""
+            SELECT n.id, n.path, nc.body
+            FROM notes n
+            JOIN note_content nc ON n.id = nc.note_id
+            WHERE n.id IN (SELECT note_id FROM tags WHERE tag = 'scaffold')
+        """):
+            body_lines = (row["body"] or "").splitlines()
+            # Look for the header within the first 20 non-blank lines
+            header_line_idx = None
+            seen_non_blank = 0
+            for idx, line in enumerate(body_lines):
+                if line.strip():
+                    seen_non_blank += 1
+                if _header_re.match(line):
+                    header_line_idx = idx
+                    break
+                if seen_non_blank >= 20:
+                    break
+
+            if header_line_idx is None:
+                issues.append({
+                    "rule": "scaffold-prompt",
+                    "severity": "error",
+                    "note_id": row["id"],
+                    "note_path": row["path"],
+                    "message": (
+                        "Scaffold is missing the verbatim user prompt as its first section. "
+                        "Every scaffold MUST open with a `## User Prompt (VERBATIM — gospel)` "
+                        "header followed by the user's original question as a blockquote. "
+                        "This is the gospel rule — the dispatcher re-reads the prompt from "
+                        "this section at every downstream step."
+                    ),
+                })
+                continue
+
+            # Check for non-empty blockquote after the header (>= 50 chars total,
+            # which is a loose floor — a real prompt will be much longer).
+            quote_chars = 0
+            for line in body_lines[header_line_idx + 1:]:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                if stripped.startswith(">"):
+                    quote_chars += len(stripped.lstrip("> ").strip())
+                elif stripped.startswith("##"):
+                    break  # hit next header without finding quoted content
+                else:
+                    # some scaffolds paste the prompt as plain text without
+                    # the blockquote prefix — accept if substantive.
+                    quote_chars += len(stripped)
+                    break
+
+            if quote_chars < 50:
+                issues.append({
+                    "rule": "scaffold-prompt",
+                    "severity": "warning",
+                    "note_id": row["id"],
+                    "note_path": row["path"],
+                    "message": (
+                        f"Scaffold has the verbatim-prompt header but the content after it "
+                        f"is empty or too short ({quote_chars} chars). Paste the user's "
+                        f"full prompt as a blockquote under the header."
+                    ),
+                })
+
+    if "provenance" in rules_to_run:
+        # Verify the `--suggested-by` data-flow chain forms a rooted tree
+        # (or forest) across all fetched source notes:
+        #
+        #   1. At least one seed source exists (a fetched note with no
+        #      breadcrumb) — the loop has a starting point.
+        #   2. Every non-seed source has at least one breadcrumb pointing at
+        #      another source note that exists in the vault (reachable from
+        #      a seed through one or more breadcrumb hops).
+        #   3. Every breadcrumb's wiki-link target is a real note id — no
+        #      dangling backlinks.
+        #
+        # Previous version used `breadcrumb_count < max(2, source_count // 5)`
+        # which was easy to game by backfilling N//5 unrelated breadcrumbs.
+        # The rooted-tree check cannot be satisfied without an actual chain.
+        import re as _re
+        _breadcrumb_re = _re.compile(r"\*Suggested by \[\[([^\]]+)\]\]")
+
+        source_rows = list(conn.execute(
+            "SELECT n.id, n.path, nc.body "
+            "FROM notes n "
+            "JOIN note_content nc ON n.id = nc.note_id "
+            "WHERE n.source IS NOT NULL "
+            "AND n.id NOT LIKE '\\_%' ESCAPE '\\' "
+            "AND n.type NOT IN ('index','raw','moc')"
+        ))
+
+        if len(source_rows) <= 5:
+            # Small corpora: bouncing loop may not have fired by design.
+            # Skip the structural check; fall back to presence check only.
+            pass
+        else:
+            all_note_ids = {
+                r["id"] for r in conn.execute("SELECT id FROM notes")
+            }
+
+            source_breadcrumbs: dict[str, list[str]] = {}
+            for r in source_rows:
+                targets = _breadcrumb_re.findall(r["body"] or "")
+                # Keep only the wiki-link name before any `|display` pipe.
+                cleaned = [t.split("|", 1)[0].strip() for t in targets]
+                source_breadcrumbs[r["id"]] = cleaned
+
+            seeds = [nid for nid, crumbs in source_breadcrumbs.items() if not crumbs]
+            non_seeds = [nid for nid, crumbs in source_breadcrumbs.items() if crumbs]
+
+            # Condition 1: at least one seed.
+            if not seeds:
+                issues.append({
+                    "rule": "provenance",
+                    "severity": "error",
+                    "note_id": "<vault>",
+                    "message": (
+                        f"Provenance graph has no seed: every one of {len(source_rows)} source notes "
+                        f"carries a `*Suggested by [[...]]` breadcrumb, which is impossible for a real "
+                        f"research session. The guided reading loop must start from at least one seed "
+                        f"fetch with no suggester."
+                    ),
+                })
+
+            # Condition 2 + 3: verify graph is rooted at seeds and no dangling targets.
+            if non_seeds:
+                dangling: list[tuple[str, str]] = []
+                for nid in non_seeds:
+                    for target in source_breadcrumbs[nid]:
+                        if target not in all_note_ids:
+                            dangling.append((nid, target))
+
+                for src_id, target in dangling[:10]:  # cap output
+                    issues.append({
+                        "rule": "provenance",
+                        "severity": "error",
+                        "note_id": src_id,
+                        "message": (
+                            f"Breadcrumb `[[{target}]]` points at a note id that does not exist in the "
+                            f"vault. Either the target was deleted, or the breadcrumb was hand-written "
+                            f"without a real source. Re-fetch with `--suggested-by <real-note-id>`."
+                        ),
+                    })
+
+                # BFS from seeds to verify connectivity.
+                reachable = set(seeds)
+                frontier = list(seeds)
+                # Build reverse map: suggester -> notes it sourced
+                suggester_to_sourced: dict[str, list[str]] = {}
+                for nid, crumbs in source_breadcrumbs.items():
+                    for t in crumbs:
+                        suggester_to_sourced.setdefault(t, []).append(nid)
+                while frontier:
+                    current = frontier.pop()
+                    for child in suggester_to_sourced.get(current, []):
+                        if child not in reachable:
+                            reachable.add(child)
+                            frontier.append(child)
+
+                unreachable = [nid for nid in non_seeds if nid not in reachable]
+                if unreachable:
+                    issues.append({
+                        "rule": "provenance",
+                        "severity": "error",
+                        "note_id": "<vault>",
+                        "message": (
+                            f"{len(unreachable)} source note(s) have breadcrumbs but are not reachable "
+                            f"from any seed through the provenance graph — the chain is disconnected. "
+                            f"Disconnected islands usually mean an agent fabricated breadcrumbs "
+                            f"retroactively without following the guided reading loop. First few: "
+                            f"{', '.join(unreachable[:5])}"
+                        ),
+                    })
+
+            # Condition: coverage. At least half of non-seed sources should have a breadcrumb.
+            # (Cheap heuristic: the count of non-seeds is the count of sources with at least
+            # one breadcrumb; compare to the count of sources that SHOULD have one.)
+            non_seed_ratio = len(non_seeds) / max(len(source_rows), 1)
+            # If there is exactly one seed and no non-seeds, the loop never fired.
+            if len(source_rows) > 5 and len(non_seeds) == 0:
+                issues.append({
+                    "rule": "provenance",
+                    "severity": "error",
+                    "note_id": "<vault>",
+                    "message": (
+                        f"Vault has {len(source_rows)} fetched source notes but ZERO "
+                        f"`*Suggested by [[...]]` breadcrumbs. The bouncing reading loop never "
+                        f"fired — every fetch was a flat batch with no link back to the source "
+                        f"that proposed it. Use `$HPR fetch ... --suggested-by <source-note-id> "
+                        f"--suggested-by-reason \"<why>\"` for every follow-up fetch."
+                    ),
+                })
+            elif non_seed_ratio < 0.3 and len(source_rows) > 10:
+                # Less than 30% of the corpus came from analyst recommendations.
+                # The guided reading loop effectively didn't fire — this is the
+                # exact failure mode both v2 runs exhibited (3/19 and 2/33).
+                # Error severity because it blocks Checkpoint 2.
+                issues.append({
+                    "rule": "provenance",
+                    "severity": "error",
+                    "note_id": "<vault>",
+                    "message": (
+                        f"Only {len(non_seeds)}/{len(source_rows)} source notes ({non_seed_ratio:.0%}) "
+                        f"have breadcrumbs — the guided reading loop did not fire. The initial batch "
+                        f"fetch is not the whole corpus; after fetching seeds you MUST spawn analysts "
+                        f"to propose next targets, then fetch those with `--suggested-by`. Target: "
+                        f"at least 30% of sources should come from analyst recommendations."
+                    ),
+                })
+            elif non_seed_ratio < 0.5 and len(source_rows) > 10:
+                # Between 30% and 50% — under-firing but marginal. Warning only.
+                issues.append({
+                    "rule": "provenance",
+                    "severity": "warning",
+                    "note_id": "<vault>",
+                    "message": (
+                        f"Only {len(non_seeds)}/{len(source_rows)} source notes ({non_seed_ratio:.0%}) "
+                        f"have breadcrumbs. The bouncing reading loop is under-firing — most "
+                        f"fetches look like flat seeds rather than analyst-driven discoveries."
+                    ),
+                })
+
+    if "analyst-coverage" in rules_to_run:
+        # Detect when source notes were fetched but few were analyzed (i.e.,
+        # spawned a hyperresearch-analyst that wrote an extract note). An
+        # extract note is identified by carrying the `extract` tag.
+        #
+        # Rule applies UNCONDITIONALLY — previous versions gated on
+        # `source_count >= 10` which silently disabled the rule for small
+        # corpora (a compare session with 8 named entities could ship zero
+        # extracts and pass). The gate is removed.
+        source_count_row = conn.execute(
+            "SELECT COUNT(*) as c FROM notes n "
+            "WHERE n.source IS NOT NULL "
+            "AND n.id NOT LIKE '\\_%' ESCAPE '\\' "
+            "AND n.type NOT IN ('index','raw','moc') "
+            "AND n.id NOT IN (SELECT note_id FROM tags WHERE tag = 'extract') "
+            "AND n.id NOT IN (SELECT note_id FROM tags WHERE tag = 'scaffold') "
+            "AND n.id NOT IN (SELECT note_id FROM tags WHERE tag = 'comparison')"
+        ).fetchone()
+        source_count = source_count_row["c"] if source_count_row else 0
+
+        extract_count_row = conn.execute(
+            "SELECT COUNT(DISTINCT note_id) as c FROM tags WHERE tag = 'extract'"
+        ).fetchone()
+        extract_count = extract_count_row["c"] if extract_count_row else 0
+
+        # Require 1/3 coverage (error floor at 1/4). Even a 2-source session
+        # needs at least 1 extract — the analyst is mandatory, not optional.
+        if source_count >= 1:
+            required_extracts = max(1, source_count // 3)
+            error_floor = max(1, source_count // 4)
+            if extract_count < required_extracts:
+                ratio = extract_count / source_count if source_count else 0
+                issues.append({
+                    "rule": "analyst-coverage",
+                    "severity": "error" if extract_count < error_floor else "warning",
+                    "note_id": "<vault>",
+                    "message": (
+                        f"Vault has {source_count} fetched source notes but only {extract_count} "
+                        f"extract notes ({ratio:.0%} coverage, need ≥{required_extracts}). "
+                        f"The analyst was skipped on most sources. Spawn "
+                        f"hyperresearch-analyst (mode=extract or mode=guided) on the "
+                        f"unanalyzed sources during curation. Target: at least 1 extract per "
+                        f"3 sources (floor of 1 for any corpus size)."
+                    ),
+                })
+
+    if "orphaned-raw-files" in rules_to_run:
+        # Walk research/raw/ and flag files whose stem doesn't match any note
+        # id in the vault. These are leftovers from the pre-Batch-2.5 `note rm`
+        # which never touched raw files. A cheap disk-leak detector.
+        raw_dir = vault.root / "research" / "raw"
+        if raw_dir.is_dir():
+            note_ids = {r["id"] for r in conn.execute("SELECT id FROM notes")}
+            for raw_file in raw_dir.iterdir():
+                if not raw_file.is_file():
+                    continue
+                # Only flag known raw extensions; ignore any README etc.
+                if raw_file.suffix.lower() not in {".pdf", ".png", ".jpg", ".jpeg", ".gif", ".webp"}:
+                    continue
+                if raw_file.stem not in note_ids:
+                    issues.append({
+                        "rule": "orphaned-raw-files",
+                        "severity": "warning",
+                        "note_id": raw_file.stem,
+                        "note_path": str(raw_file.relative_to(vault.root).as_posix()),
+                        "message": (
+                            f"Raw file {raw_file.name} has no matching note in the vault. "
+                            f"Likely a leftover from an old `note rm` that didn't clean up "
+                            f"raw files. Delete it manually or let repair handle it."
+                        ),
+                    })
+
+    if "workflow" in rules_to_run:
+        # Detect research sessions that skipped the mandatory process steps.
+        # Heuristic: a note with a research-output signal (final_report in id,
+        # type=moc, or tag=synthesis) means a research session ran. If that
+        # session didn't produce a scaffold note AND a comparison note, the
+        # protocol was skipped.
+        def _count_by_tag(tag: str) -> int:
+            row = conn.execute(
+                "SELECT COUNT(DISTINCT note_id) as c FROM tags WHERE tag = ?",
+                (tag,),
+            ).fetchone()
+            return row["c"] if row else 0
+
+        has_research_output = conn.execute("""
+            SELECT COUNT(*) as c FROM notes n
+            WHERE n.id LIKE '%final_report%'
+               OR n.type = 'moc'
+               OR n.id IN (SELECT note_id FROM tags WHERE tag = 'synthesis')
+        """).fetchone()["c"]
+
+        scaffold_count = _count_by_tag("scaffold")
+        comparison_count = _count_by_tag("comparison")
+        extract_count = _count_by_tag("extract")
+
+        if has_research_output > 0:
+            if scaffold_count == 0:
+                issues.append({
+                    "rule": "workflow",
+                    "severity": "error",
+                    "note_id": "<vault>",
+                    "message": (
+                        f"Vault has {has_research_output} research-output note(s) "
+                        f"but 0 scaffold notes. Step 7 was skipped. "
+                        f"Research sessions must produce a `scaffold` note before the draft."
+                    ),
+                })
+            if comparison_count == 0:
+                issues.append({
+                    "rule": "workflow",
+                    "severity": "error",
+                    "note_id": "<vault>",
+                    "message": (
+                        f"Vault has {has_research_output} research-output note(s) "
+                        f"but 0 comparison notes. Step 8 was skipped. "
+                        f"Research sessions must produce a `comparison` note before the draft."
+                    ),
+                })
+
+        # Flag extract notes that are missing the parent link
+        for row in conn.execute("""
+            SELECT n.id, n.path FROM notes n
+            WHERE n.id IN (SELECT note_id FROM tags WHERE tag = 'extract')
+              AND (n.parent IS NULL OR n.parent = '')
+        """):
+            issues.append({
+                "rule": "workflow",
+                "severity": "warning",
+                "note_id": row["id"],
+                "note_path": row["path"],
+                "message": "Extract note missing --parent source-id. The chain of custody is broken.",
+            })
+
+    if "uncurated" in rules_to_run:
+        # Any note that has moved past draft without tier/content_type classification
+        # is a curation failure. Exempt: draft notes (expected raw), index/raw/moc
+        # types (not sources), and notes whose id starts with _ (auto-generated
+        # index notes like _most-linked, _stale, _orphans).
+        for row in conn.execute(
+            "SELECT n.id, n.path, n.status, n.tier, n.content_type FROM notes n "
+            "WHERE n.type NOT IN ('index','raw','moc') "
+            "AND n.id NOT LIKE '\\_%' ESCAPE '\\' "
+            "AND n.status != 'draft' "
+            "AND (n.tier IS NULL OR n.tier = 'unknown' "
+            "     OR n.content_type IS NULL OR n.content_type = 'unknown')"
+        ):
+            missing = []
+            if not row["tier"] or row["tier"] == "unknown":
+                missing.append("tier")
+            if not row["content_type"] or row["content_type"] == "unknown":
+                missing.append("content_type")
+            issues.append({
+                "rule": "uncurated",
+                "severity": "warning",
+                "note_id": row["id"],
+                "note_path": row["path"],
+                "message": f"Note is {row['status']} but missing {'/'.join(missing)}. Run curation pass.",
             })
 
     if "singleton-tags" in rules_to_run:
@@ -181,6 +829,34 @@ def lint(
                 "note_path": row["path"],
                 "message": f"Last reviewed {row['reviewed'][:10]}. Consider re-reviewing.",
             })
+
+    # Audit-gate self-certification post-check. For each CRITICAL finding
+    # that was marked `fixed_at`, we queued its implied lint rule for
+    # re-running via rules_to_run. Now that the full lint pass is done,
+    # check whether the rule still emitted errors. If yes, the agent marked
+    # a CRITICAL resolved without actually fixing the underlying vault state
+    # — emit a self-cert violation error that blocks the save gate.
+    if audit_gate_guards:
+        for guard in audit_gate_guards:
+            rule_errors = [
+                i for i in issues
+                if i.get("rule") == guard["rule"] and i.get("severity") == "error"
+            ]
+            if rule_errors:
+                issues.append({
+                    "rule": "audit-gate",
+                    "severity": "error",
+                    "note_id": "<vault>",
+                    "message": (
+                        f"SELF-CERTIFICATION VIOLATION: CRITICAL [{guard['critical_id']}] "
+                        f"was marked `fixed_at` in research/audit_findings.json, but lint "
+                        f"rule `{guard['rule']}` still returns {len(rule_errors)} error(s). "
+                        f"The finding was '{guard['description']}'. The draft's `fixed_at` "
+                        f"marker does not match the vault's actual state — you must fix the "
+                        f"underlying issue (not just the bookkeeping). Run "
+                        f"`$HPR lint --rule {guard['rule']} -j` to see what's still broken."
+                    ),
+                })
 
     summary = {
         "errors": sum(1 for i in issues if i.get("severity") == "error"),

--- a/src/hyperresearch/cli/lint.py
+++ b/src/hyperresearch/cli/lint.py
@@ -185,8 +185,8 @@ def lint(
                             "severity": "error",
                             "note_id": "<vault>",
                             "message": (
-                                f"Most recent conformance audit returned status=failed. "
-                                f"Investigate the findings and re-run the auditor."
+                                "Most recent conformance audit returned status=failed. "
+                                "Investigate the findings and re-run the auditor."
                             ),
                         })
 
@@ -230,7 +230,7 @@ def lint(
                 # broad — false matches are fine (they cause a re-check
                 # which passes harmlessly); missing a match is the failure
                 # mode we're guarding against.
-                _KW_TO_RULE = [
+                kw_to_rule = [
                     # scaffold-prompt (verbatim prompt gospel rule)
                     ("scaffold-prompt", "scaffold-prompt"),
                     ("scaffold_prompt", "scaffold-prompt"),
@@ -305,7 +305,7 @@ def lint(
                         desc = (str(c.get("description", "")) + " " +
                                 str(c.get("id", ""))).lower()
                         matched = None
-                        for kw, rule_name in _KW_TO_RULE:
+                        for kw, rule_name in kw_to_rule:
                             if kw in desc:
                                 matched = rule_name
                                 break

--- a/src/hyperresearch/cli/note.py
+++ b/src/hyperresearch/cli/note.py
@@ -24,6 +24,8 @@ def note_new(
     status: str = typer.Option("draft", "--status", "-s", help="Initial status"),
     summary: str | None = typer.Option(None, "--summary", help="One-line summary"),
     source: str | None = typer.Option(None, "--source", help="Source URL or path"),
+    tier: str | None = typer.Option(None, "--tier", help="Epistemic tier: ground_truth|institutional|practitioner|commentary|unknown"),
+    content_type: str | None = typer.Option(None, "--content-type", help="Artifact kind: paper|docs|article|blog|forum|dataset|policy|code|book|transcript|review|unknown"),
     template: str | None = typer.Option(None, "--template", "-T", help="Template: note|concept|reference|guide|comparison|moc"),
     edit: bool = typer.Option(False, "--edit", "-e", help="Open in $EDITOR"),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON output"),
@@ -38,7 +40,29 @@ def note_new(
 
     from hyperresearch.core.note import write_note
     from hyperresearch.core.vault import Vault
-    from hyperresearch.models.note import slugify
+    from hyperresearch.models.note import ContentType, Tier, slugify
+
+    # Validate enums up-front so invalid values fail clearly
+    if tier is not None:
+        try:
+            Tier(tier)
+        except ValueError:
+            valid = ", ".join(t.value for t in Tier)
+            if json_output:
+                output(error(f"Invalid --tier '{tier}'. Must be one of: {valid}", "INVALID_TIER"), json_mode=True)
+            else:
+                console.print(f"[red]Invalid --tier '{tier}'.[/] Must be one of: {valid}")
+            raise typer.Exit(1)
+    if content_type is not None:
+        try:
+            ContentType(content_type)
+        except ValueError:
+            valid = ", ".join(c.value for c in ContentType)
+            if json_output:
+                output(error(f"Invalid --content-type '{content_type}'. Must be one of: {valid}", "INVALID_CONTENT_TYPE"), json_mode=True)
+            else:
+                console.print(f"[red]Invalid --content-type '{content_type}'.[/] Must be one of: {valid}")
+            raise typer.Exit(1)
 
     vault = Vault.discover()
     vault.auto_sync()
@@ -92,11 +116,11 @@ def note_new(
             console.print(f"[yellow]Template '{template}' not found, using default.[/]")
             path = write_note(vault.notes_dir, title, body=body, tags=tags, status=status,
                               note_type=note_type, parent=parent, summary=summary,
-                              source=source)
+                              source=source, tier=tier, content_type=content_type)
     else:
         path = write_note(vault.notes_dir, title, body=body, tags=tags, status=status,
                           note_type=note_type, parent=parent, summary=summary,
-                          source=source)
+                          source=source, tier=tier, content_type=content_type)
 
     # Read back the note ID (may have been collision-adjusted)
     from hyperresearch.core.note import read_note
@@ -154,6 +178,8 @@ def note_show(
         data = {
             "id": row["id"], "title": row["title"], "path": row["path"],
             "status": row["status"], "type": row["type"], "tags": tags,
+            "tier": row["tier"] if "tier" in row.keys() else None,
+            "content_type": row["content_type"] if "content_type" in row.keys() else None,
             "created": row["created"], "updated": row["updated"],
             "word_count": row["word_count"], "source": row["source"],
             "parent": row["parent"], "summary": row["summary"],
@@ -232,6 +258,8 @@ def note_list(
     note_type: str | None = typer.Option(None, "--type", help="Filter by type"),
     tag: str | None = typer.Option(None, "--tag", "-t", help="Filter by tag"),
     parent: str | None = typer.Option(None, "--parent", "-p", help="Filter by parent"),
+    tier: str | None = typer.Option(None, "--tier", help="Filter by epistemic tier: ground_truth|institutional|practitioner|commentary|unknown"),
+    content_type: str | None = typer.Option(None, "--content-type", help="Filter by artifact kind: paper|docs|article|blog|forum|dataset|policy|code|book|transcript|review|unknown"),
     sort: str = typer.Option("updated", "--sort", help="Sort: created|updated|title|words"),
     limit: int = typer.Option(20, "--limit", "-l", help="Max results"),
     all_notes: bool = typer.Option(False, "--all", "-a", help="Return all notes (no limit)"),
@@ -239,6 +267,29 @@ def note_list(
 ) -> None:
     """List notes with optional filters."""
     from hyperresearch.core.vault import Vault
+    from hyperresearch.models.note import ContentType, Tier
+
+    # Validate enums up-front
+    if tier is not None:
+        try:
+            Tier(tier)
+        except ValueError:
+            valid = ", ".join(t.value for t in Tier)
+            if json_output:
+                output(error(f"Invalid --tier '{tier}'. Must be one of: {valid}", "INVALID_TIER"), json_mode=True)
+            else:
+                console.print(f"[red]Invalid --tier '{tier}'.[/] Must be one of: {valid}")
+            raise typer.Exit(1)
+    if content_type is not None:
+        try:
+            ContentType(content_type)
+        except ValueError:
+            valid = ", ".join(c.value for c in ContentType)
+            if json_output:
+                output(error(f"Invalid --content-type '{content_type}'. Must be one of: {valid}", "INVALID_CONTENT_TYPE"), json_mode=True)
+            else:
+                console.print(f"[red]Invalid --content-type '{content_type}'.[/] Must be one of: {valid}")
+            raise typer.Exit(1)
 
     vault = Vault.discover()
     vault.auto_sync()
@@ -258,6 +309,12 @@ def note_list(
     if tag:
         clauses.append("n.id IN (SELECT note_id FROM tags WHERE tag = ?)")
         params.append(tag.lower())
+    if tier:
+        clauses.append("n.tier = ?")
+        params.append(tier)
+    if content_type:
+        clauses.append("n.content_type = ?")
+        params.append(content_type)
 
     where = " AND ".join(clauses) if clauses else "1=1"
 
@@ -286,6 +343,8 @@ def note_list(
             "path": row["path"],
             "status": row["status"],
             "type": row["type"],
+            "tier": row["tier"] if "tier" in row.keys() else None,
+            "content_type": row["content_type"] if "content_type" in row.keys() else None,
             "tags": tag_list,
             "word_count": row["word_count"],
             "summary": row["summary"],
@@ -334,6 +393,8 @@ def note_update(
     set_summary: str | None = typer.Option(None, "--summary", help="Set summary"),
     set_parent: str | None = typer.Option(None, "--parent", "-p", help="Set parent topic"),
     set_source: str | None = typer.Option(None, "--source", help="Set source URL/path"),
+    set_tier: str | None = typer.Option(None, "--tier", help="Set epistemic tier: ground_truth|institutional|practitioner|commentary|unknown"),
+    set_content_type: str | None = typer.Option(None, "--content-type", help="Set artifact kind: paper|docs|article|blog|forum|dataset|policy|code|book|transcript|review|unknown"),
     deprecate: bool = typer.Option(False, "--deprecate", help="Mark as deprecated"),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON output"),
 ) -> None:
@@ -343,6 +404,29 @@ def note_update(
     from hyperresearch.core.frontmatter import parse_frontmatter, serialize_frontmatter
     from hyperresearch.core.sync import compute_sync_plan, execute_sync
     from hyperresearch.core.vault import Vault
+    from hyperresearch.models.note import ContentType, Tier
+
+    # Validate enums up-front
+    if set_tier is not None:
+        try:
+            Tier(set_tier)
+        except ValueError:
+            valid = ", ".join(t.value for t in Tier)
+            if json_output:
+                output(error(f"Invalid --tier '{set_tier}'. Must be one of: {valid}", "INVALID_TIER"), json_mode=True)
+            else:
+                console.print(f"[red]Invalid --tier '{set_tier}'.[/] Must be one of: {valid}")
+            raise typer.Exit(1)
+    if set_content_type is not None:
+        try:
+            ContentType(set_content_type)
+        except ValueError:
+            valid = ", ".join(c.value for c in ContentType)
+            if json_output:
+                output(error(f"Invalid --content-type '{set_content_type}'. Must be one of: {valid}", "INVALID_CONTENT_TYPE"), json_mode=True)
+            else:
+                console.print(f"[red]Invalid --content-type '{set_content_type}'.[/] Must be one of: {valid}")
+            raise typer.Exit(1)
 
     vault = Vault.discover()
     vault.auto_sync()
@@ -380,6 +464,12 @@ def note_update(
     if set_source is not None:
         meta.source = set_source
         changed.append("source")
+    if set_tier is not None:
+        meta.tier = set_tier
+        changed.append(f"tier={set_tier}")
+    if set_content_type is not None:
+        meta.content_type = set_content_type
+        changed.append(f"content_type={set_content_type}")
     if deprecate:
         meta.deprecated = True
         meta.status = "deprecated"
@@ -448,11 +538,22 @@ def note_rm(
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON output"),
 ) -> None:
-    """Delete a note."""
+    """Delete a note and its associated raw file and assets.
+
+    Previous versions only unlinked the `.md` file, leaving raw PDFs under
+    `research/raw/` and assets under `research/assets/<id>/` as orphans.
+    Every fetch-then-delete cycle leaked disk. The current implementation
+    also removes:
+      - the raw file referenced in the note's `raw_file` frontmatter field
+      - any entries in the `assets` table and their files on disk
+    """
+    import shutil
     from hyperresearch.core.vault import Vault
 
     vault = Vault.discover()
-    row = vault.db.execute("SELECT path FROM notes WHERE id = ?", (note_id,)).fetchone()
+    row = vault.db.execute(
+        "SELECT path FROM notes WHERE id = ?", (note_id,)
+    ).fetchone()
     if not row:
         if json_output:
             output(error(f"Note not found: {note_id}", "NOT_FOUND"), json_mode=True)
@@ -464,6 +565,34 @@ def note_rm(
     if not force and not json_output:
         typer.confirm(f"Delete {row['path']}?", abort=True)
 
+    removed_raw: str | None = None
+    removed_assets: list[str] = []
+
+    # Read raw_file straight from the markdown frontmatter — the DB row
+    # may not carry that field if the schema was synced before the column
+    # existed. File parsing is authoritative.
+    if file_path.exists():
+        try:
+            from hyperresearch.core.frontmatter import parse_frontmatter
+            text = file_path.read_text(encoding="utf-8-sig")
+            meta, _ = parse_frontmatter(text)
+            if meta.raw_file:
+                raw_path = vault.root / "research" / meta.raw_file
+                if raw_path.exists():
+                    raw_path.unlink()
+                    removed_raw = str(raw_path.relative_to(vault.root).as_posix())
+        except Exception:
+            pass
+
+    # Assets directory
+    assets_dir = vault.root / "research" / "assets" / note_id
+    if assets_dir.exists() and assets_dir.is_dir():
+        for asset_file in assets_dir.iterdir():
+            if asset_file.is_file():
+                removed_assets.append(asset_file.name)
+        shutil.rmtree(assets_dir, ignore_errors=True)
+
+    # Finally, unlink the .md file
     if file_path.exists():
         file_path.unlink()
 
@@ -473,9 +602,20 @@ def note_rm(
     plan = compute_sync_plan(vault)
     execute_sync(vault, plan)
 
+    payload: dict = {"deleted": note_id}
+    if removed_raw:
+        payload["removed_raw"] = removed_raw
+    if removed_assets:
+        payload["removed_assets"] = removed_assets
+
     if json_output:
-        output(success({"deleted": note_id}, vault=str(vault.root)), json_mode=True)
+        output(success(payload, vault=str(vault.root)), json_mode=True)
     else:
-        console.print(f"[red]Deleted:[/] {note_id}")
+        msg = f"[red]Deleted:[/] {note_id}"
+        if removed_raw:
+            msg += f"\n  raw: {removed_raw}"
+        if removed_assets:
+            msg += f"\n  assets: {len(removed_assets)} file(s)"
+        console.print(msg)
 
 

--- a/src/hyperresearch/cli/note.py
+++ b/src/hyperresearch/cli/note.py
@@ -178,8 +178,10 @@ def note_show(
         data = {
             "id": row["id"], "title": row["title"], "path": row["path"],
             "status": row["status"], "type": row["type"], "tags": tags,
-            "tier": row["tier"] if "tier" in row else None,  # noqa: SIM401 (sqlite3.Row has no .get())
-            "content_type": row["content_type"] if "content_type" in row else None,  # noqa: SIM401
+            # sqlite3.Row.__contains__ is broken (returns False even for present keys),
+            # so use row.keys() explicitly. SIM118 + SIM401 are noqa'd accordingly.
+            "tier": row["tier"] if "tier" in row.keys() else None,  # noqa: SIM118
+            "content_type": row["content_type"] if "content_type" in row.keys() else None,  # noqa: SIM118
             "created": row["created"], "updated": row["updated"],
             "word_count": row["word_count"], "source": row["source"],
             "parent": row["parent"], "summary": row["summary"],
@@ -343,8 +345,9 @@ def note_list(
             "path": row["path"],
             "status": row["status"],
             "type": row["type"],
-            "tier": row["tier"] if "tier" in row else None,  # noqa: SIM401 (sqlite3.Row has no .get())
-            "content_type": row["content_type"] if "content_type" in row else None,  # noqa: SIM401
+            # sqlite3.Row.__contains__ is broken; row.keys() is reliable.
+            "tier": row["tier"] if "tier" in row.keys() else None,  # noqa: SIM118
+            "content_type": row["content_type"] if "content_type" in row.keys() else None,  # noqa: SIM118
             "tags": tag_list,
             "word_count": row["word_count"],
             "summary": row["summary"],

--- a/src/hyperresearch/cli/note.py
+++ b/src/hyperresearch/cli/note.py
@@ -581,8 +581,17 @@ def note_rm(
             text = file_path.read_text(encoding="utf-8-sig")
             meta, _ = parse_frontmatter(text)
             if meta.raw_file:
-                raw_path = vault.root / "research" / meta.raw_file
-                if raw_path.exists():
+                # Resolve and guard against path traversal — a malicious or
+                # corrupted frontmatter could set raw_file to "../../etc/passwd".
+                # Refuse to unlink anything outside <vault>/research/.
+                research_root = (vault.root / "research").resolve()
+                raw_path = (vault.root / "research" / meta.raw_file).resolve()
+                try:
+                    raw_path.relative_to(research_root)
+                    inside_vault = True
+                except ValueError:
+                    inside_vault = False
+                if inside_vault and raw_path.exists() and raw_path.is_file():
                     raw_path.unlink()
                     removed_raw = str(raw_path.relative_to(vault.root).as_posix())
         except Exception:

--- a/src/hyperresearch/cli/note.py
+++ b/src/hyperresearch/cli/note.py
@@ -178,8 +178,8 @@ def note_show(
         data = {
             "id": row["id"], "title": row["title"], "path": row["path"],
             "status": row["status"], "type": row["type"], "tags": tags,
-            "tier": row["tier"] if "tier" in row.keys() else None,
-            "content_type": row["content_type"] if "content_type" in row.keys() else None,
+            "tier": row["tier"] if "tier" in row else None,  # noqa: SIM401 (sqlite3.Row has no .get())
+            "content_type": row["content_type"] if "content_type" in row else None,  # noqa: SIM401
             "created": row["created"], "updated": row["updated"],
             "word_count": row["word_count"], "source": row["source"],
             "parent": row["parent"], "summary": row["summary"],
@@ -343,8 +343,8 @@ def note_list(
             "path": row["path"],
             "status": row["status"],
             "type": row["type"],
-            "tier": row["tier"] if "tier" in row.keys() else None,
-            "content_type": row["content_type"] if "content_type" in row.keys() else None,
+            "tier": row["tier"] if "tier" in row else None,  # noqa: SIM401 (sqlite3.Row has no .get())
+            "content_type": row["content_type"] if "content_type" in row else None,  # noqa: SIM401
             "tags": tag_list,
             "word_count": row["word_count"],
             "summary": row["summary"],
@@ -548,6 +548,7 @@ def note_rm(
       - any entries in the `assets` table and their files on disk
     """
     import shutil
+
     from hyperresearch.core.vault import Vault
 
     vault = Vault.discover()

--- a/src/hyperresearch/cli/search.py
+++ b/src/hyperresearch/cli/search.py
@@ -13,6 +13,8 @@ def search(
     tag: list[str] = typer.Option([], "--tag", "-t", help="Filter by tag (AND logic)"),
     status: str | None = typer.Option(None, "--status", "-s", help="Filter by status"),
     note_type: str | None = typer.Option(None, "--type", help="Filter by type"),
+    tier: str | None = typer.Option(None, "--tier", help="Filter by epistemic tier: ground_truth|institutional|practitioner|commentary|unknown"),
+    content_type: str | None = typer.Option(None, "--content-type", help="Filter by artifact kind: paper|docs|article|blog|forum|dataset|policy|code|book|transcript|review|unknown"),
     parent: str | None = typer.Option(None, "--parent", "-p", help="Filter by parent topic"),
     after: str | None = typer.Option(None, "--after", help="Created after date (YYYY-MM-DD)"),
     before: str | None = typer.Option(None, "--before", help="Created before date (YYYY-MM-DD)"),
@@ -32,8 +34,31 @@ def search(
 ) -> None:
     """Full-text search across all notes."""
     from hyperresearch.core.vault import Vault, VaultError
+    from hyperresearch.models.note import ContentType, Tier
     from hyperresearch.search.filters import SearchFilters
     from hyperresearch.search.fts import search_fts
+
+    # Validate enums up-front
+    if tier is not None:
+        try:
+            Tier(tier)
+        except ValueError:
+            valid = ", ".join(t.value for t in Tier)
+            if json_output:
+                output(error(f"Invalid --tier '{tier}'. Must be one of: {valid}", "INVALID_TIER"), json_mode=True)
+            else:
+                console.print(f"[red]Invalid --tier '{tier}'.[/] Must be one of: {valid}")
+            raise typer.Exit(1)
+    if content_type is not None:
+        try:
+            ContentType(content_type)
+        except ValueError:
+            valid = ", ".join(c.value for c in ContentType)
+            if json_output:
+                output(error(f"Invalid --content-type '{content_type}'. Must be one of: {valid}", "INVALID_CONTENT_TYPE"), json_mode=True)
+            else:
+                console.print(f"[red]Invalid --content-type '{content_type}'.[/] Must be one of: {valid}")
+            raise typer.Exit(1)
 
     try:
         vault = Vault.discover()
@@ -49,6 +74,8 @@ def search(
         tags=tag or None,
         status=status,
         note_type=note_type,
+        tier=tier,
+        content_type=content_type,
         parent=parent,
         after=after,
         before=before,

--- a/src/hyperresearch/core/agent_docs.py
+++ b/src/hyperresearch/core/agent_docs.py
@@ -26,276 +26,11 @@ This project uses hyperresearch as an agent-driven research knowledge base. The 
 
 ### MANDATORY: How to do research
 
-When the user asks you to research a topic, **you MUST follow this workflow**. Do NOT use WebFetch for source pages — use `{hpr} fetch` instead. It runs a real headless browser, handles JavaScript, bypasses bot detection, saves full content with screenshots and images, and indexes everything for future sessions.
+When the user asks you to research a topic, follow the full step-by-step workflow in `.claude/skills/hyperresearch/SKILL.md`. **Do NOT use WebFetch for source pages** — use `{hpr} fetch` instead.
 
-**This is a deep research tool.** Your job is to go down rabbit holes, cast a wide net, and collect enough raw source material to say something meaningful across it. **Over-collect, then prune.** It is better to have too many sources than too few — you can deprecate notes later, but you can't un-skip a source you never fetched.
+SKILL.md classifies your request by cognitive activity (what the output needs to DO, not what the subject IS) and routes to one of 4 modality files: SKILL-collect.md (enumerative coverage with per-entity fields), SKILL-synthesize.md (defended thesis or mechanism explanation), SKILL-compare.md (per-entity evaluation with committed recommendation), or SKILL-forecast.md (forward-looking prediction with explicit time horizon). The dispatcher owns the shared protocol (discovery, fetch, guided reading loop, curation, scaffold, comparisons, draft, audit, synthesis). Each modality file encodes only the substance rules and conformance checks specific to that activity. Read SKILL.md first — it owns the process and will tell you which modality file to open next for substance guidance.
 
-**But collection is not the goal.** Collection is a means to an argument. A report built from 30 sources that disagree, contextualize each other, and force you to take positions is worth more than a report built from 80 sources that each contribute one paragraph of description. Optimise for **depth of engagement** (each source read carefully, compared with 2–3 others, cited multiple times across the report) rather than **count of citations**. If you find yourself translating one source into one paragraph or one section, you are building a catalog — stop and restructure.
-
-**There is no time limit.** Deep research can run for hours if the topic demands it. Do multiple rounds of research — as new subtopics, angles, and questions reveal themselves, launch new rounds of fetcher subagents in parallel to chase them down. The first round uncovers the landscape; the second round digs into what you found; the third round fills gaps. Keep going.
-
-**CHECKPOINT: Before you start writing ANY draft, stop and take stock.** Run:
-```bash
-{hpr} note list -j
-```
-Don't collect sources just to hit a number. Instead, review what you have and ask:
-- What angles, subtopics, or perspectives are NOT yet covered?
-- Which existing notes reference papers, data, or sources I haven't fetched yet?
-- Are there counterarguments, alternative viewpoints, or competing theories I'm missing?
-- Do I have primary sources, or just secondhand summaries?
-
-If the answer to any of these is "yes, there's more to get" — go back and get it. Spawn more fetcher agents, search new angles, follow links from existing notes. Keep going until you genuinely can't find anything new worth adding.
-
-**Step 0: Classify the request and pick a protocol (MANDATORY)** — Different research requests need fundamentally different strategies. Source counts, primary/secondary mix, section structure, target length, analytical mode — all change based on request shape. A single universal protocol is wrong. **Before Step 1, classify the request and state your classification in writing** (in working memory or `/tmp/scaffold.md` — NOT a hyperresearch note).
-
-The 7 request types:
-
-| Type | Name | Use when |
-|---|---|---|
-| 1 | **Canonical Knowledge Retrieval** | Mature field with textbook chapters or canonical surveys; an expert would start by citing a classic source. |
-| 2 | **Market / Landscape Mapping** | Enumerable competitive analysis — list of companies, products, vendors with attributes. |
-| 3 | **Engineering / Technical How-To** | User is trying to DO something. Ideal answer is a procedure or method selection. |
-| 4 | **Interpretive / Humanities Analysis** | Subject is a text, work, tradition, or cultural phenomenon. Good answer takes a position and defends it. |
-| 5 | **Comparative Evaluation** | Prompt names multiple alternatives by name and expects a matrix + pick. |
-| 6 | **Emerging / Cutting-Edge Research** | Most useful material is <2 years old; best sources are arXiv/bioRxiv/conference papers. |
-| 7 | **Forecast / Strategy / Recommendation** | Asks what will happen or should be done; ideal answer commits to a prediction or prescription. |
-| 0 | **General Research (fallback)** | Doesn't cleanly fit one type, or genuinely spans multiple. |
-
-Overlap is expected. Classify a **primary** type and, if applicable, a **secondary** type. Apply the primary's parameter block; borrow special rules from the secondary.
-
-**State your classification** before Step 1:
-1. Primary type: #N — one-sentence justification tied to the prompt.
-2. Secondary type: #N or "none".
-3. Applied parameters (5 lines): source strategy, target length, opening-section shape, target H2 count, analytical mode.
-
-**Request-type parameter blocks** — apply the block for your primary type. These overrides take precedence over the generic defaults referenced in Step 3 and Step 7.
-
-**Type 1 — Canonical Knowledge Retrieval.** Sources: 5–15 primary (seminal papers, textbooks, canonical surveys) + 5–15 secondary. Primary-heavy. Target 6,000–10,000 words. Opening: historical/conceptual progression — how the field arrived at consensus. H2 count: 10–15, sequenced by dependency (concept → result → consequence). Analytical mode: explain WHY canonical results hold; compare competing formulations; signal which textbook to start with. Special rule: sequence by dependency, not by source.
-
-**Type 2 — Market / Landscape Mapping.** Sources: 20–50 secondary (reports, press, official docs) + 5–10 primary (filings, specs, API docs). Secondary-heavy. Target 5,000–9,000 words. Opening: market definition + segmentation + the framework used to score vendors. H2 count: 8–14, one per vendor *cluster* or category — NEVER one per individual vendor. Analytical mode: take a position on who is winning and why. Special rule: at least one comparison matrix in the body is MANDATORY. Never list vendors in isolation. If the user asked for rankings, deliver with confidence.
-
-**Type 3 — Engineering / Technical How-To.** Sources: 5–15 primary (papers, docs, GitHub, RFCs, standards) + 5–15 secondary (blog posts, tutorials, SO). Balanced. Target 4,000–8,000 words. Opening: problem statement + constraint landscape — what makes this hard. H2 count: 8–14. Analytical mode: pick a recommended approach; explain when to use alternatives. Special rule: if a method has a reference implementation, link and characterize it. Include a decision tree or selection matrix.
-
-**Type 4 — Interpretive / Humanities Analysis.** Sources: 3–10 primary (the work itself, key scholarly monographs, canonical commentary) + 10–25 secondary (critical essays, interviews, reviews). Primary-heavy for depth. Target 7,000–11,000 words. Opening: thesis + the interpretive tradition this work sits in. H2 count: **6–10** (fewer, LONGER sections — 800–1500 words each). Sections are THEMATIC, not entity-cataloged. Analytical mode: take and defend an interpretation; engage dissenting readings. Special rule: NEVER one section per character / chapter / author. Special rule: at least 2 body sections must put sources in tension with each other. Special rule: this is the type where catalog-style reports fail hardest — double-check that no section is <400 words or entity-named.
-
-**Type 5 — Comparative Evaluation.** Sources: 3–5 primary per comparand + 2–5 secondary per comparand (so N×5 to N×10 total). Depth scales with N. Target 5,000–10,000 words. Opening: the comparison framework — dimensions being scored and why they matter. H2 count: typically 1 per comparand + 2–4 synthesis sections (~8–12 total). Analytical mode: explicit scoring on each dimension + recommended pick with tradeoffs. Special rule: a comparison matrix in the body is MANDATORY. Special rule: equal depth across comparands — rebalance if uneven.
-
-**Type 6 — Emerging / Cutting-Edge Research.** Sources: 5–15 primary (preprints, conference papers, authoritative reviews if any) + 3–8 secondary (news, blog posts from authors). Primary-dominant. Target 5,000–9,000 words. Opening: the open problem + why prior approaches fell short. H2 count: 8–12. Analytical mode: honest about disagreement; forecast 2–5 years out with caveats. Special rule: if a claim is from a 2024–2026 preprint, say so — don't assume consensus. Include an explicit "What we don't know yet" section. Do NOT pad with mature-field material to hit a source count.
-
-**Type 7 — Forecast / Strategy / Recommendation.** Sources: 15–30 secondary (analyst reports, think-tanks, news) + 5–10 primary (official announcements, filings, datasets). Secondary-heavy. Target 6,000–10,000 words. Opening: the decision/question being answered + the forces shaping it. H2 count: 8–12. Analytical mode: confident prescription with explicit reasoning chain; probability language over hedging. Special rule: at least one body section must commit to a direction — not everything can be deferred to the Opinionated Synthesis. Acknowledge the time horizon explicitly.
-
-**Type 0 — General Research (fallback).** Use universal defaults: 15–25 / 30–50 / 50–80 source floors (see below), framework opening, 12–20 H2 headings, 400–600 words per H2 (see Step 7).
-
-**Source-count floors for Type 0 (fallback only):**
-- Simple factual question: 15–25 sources
-- Complex or technical topic: 30–50 sources
-- PhD-level research question: 50–80 sources
-
-**Source count is a function of request type, not topic complexity.** If you classified in Step 0, use that type's parameter block as primary guidance — fall back to the floors above only for Type 0.
-
-**Primary-heavy vs. secondary-heavy is the axis that matters most — getting this wrong is a worse failure than getting the count wrong.** Types 1, 4, 5, 6 are primary-heavy — cite originals and engage with them deeply. Types 2, 7 are secondary-heavy — triangulate across many descriptions. Type 3 is balanced. Most sources should be cited multiple times across multiple sections. If a source earns only one citation, it's probably not pulling its weight — either deepen engagement or cut it.
-
-Stop fetching when you can't find anything new worth adding, not when you hit a number. And be honest about the opposite: if you're still fetching past the type's range without a clear gap in mind, you're procrastinating on the writing.
-
-**Step 1: Check what's already known**
-```bash
-{hpr} search "topic" --include-body -j
-{hpr} sources list -j
-```
-
-**Step 2: Search broadly** — Use WebSearch with multiple queries. Don't stop at one search. Try different phrasings, related terms, and specific sub-topics. Cast a wide net.
-
-**Step 3: Fetch EVERYTHING relevant** — A `hyperresearch-fetcher` subagent is installed in `.claude/agents/`. It uses a **cheap, fast model (Haiku)** to do the actual URL fetching. **Delegate all fetching to it** — do NOT fetch URLs yourself or use WebFetch.
-
-For each URL or batch of URLs, spawn the fetcher agent:
-```
-Use the hyperresearch-fetcher agent to fetch these URLs with tag "<topic>":
-- https://example.com/article1
-- https://example.com/article2
-```
-
-**Spawn 10-20 fetcher agents in parallel per round** — give each agent 2-3 URLs max. They run on Haiku and cost fractions of a cent each. After each web search, immediately spawn fetchers for ALL promising URLs from the results — don't cherry-pick, fetch everything. Then do another round of searches and another round of fetchers. Repeat until you hit the source checkpoint.
-
-If the `hyperresearch-fetcher` agent is not available (other platforms), fall back to running the command directly:
-```bash
-{hpr} fetch "<url>" --tag <topic> -j
-```
-
-**Step 4: Go down rabbit holes** — After fetching, read the notes:
-```bash
-{hpr} note show <note-id> -j
-```
-Look for links in the content that point to **primary sources, references, related papers, deeper material, or tangentially related topics**. Fetch those too. Then read THOSE notes and follow THEIR links.
-
-**Keep going aggressively:**
-- A blog post about a paper? Fetch the paper.
-- A news article about a tool? Fetch the docs AND the GitHub repo.
-- A paper cites 3 key references? Fetch all 3.
-- A profile mentions a company? Fetch the company page.
-- Found a related topic that might be relevant? Fetch it. You can always deprecate it later.
-- A page links to raw data, CSV files, or datasets? Fetch those and analyze them.
-- A source references specific statistics without citing them? Search for and fetch the primary data.
-
-**Follow links deeply.** Don't stop at the first page. When a fetched page links to more detailed sources, primary research, raw data, or technical documentation — follow those links and fetch them too. The best insights come from primary sources, not secondhand summaries.
-
-**Run analysis when needed.** If you find raw data (tables, CSVs, statistics), don't just quote numbers — write and run code to compute real figures, verify claims, calculate trends, and produce original analysis. Concrete numbers from actual data are worth more than vague summaries.
-
-**The goal is exhaustive collection.** You are building a knowledge base that future agents will rely on. Missing a source is worse than having one extra note. Prune later during curation.
-
-**Do NOT stop collecting until you are certain you have enough breadth.** After each round of fetching, ask yourself: "Are there major angles, subtopics, or perspectives I haven't covered yet?" If yes, search and fetch more. If a topic has 5 facets, you need sources on all 5 — not just the first 2 you found. Keep going until you can confidently say the collection covers the full scope of the topic. A half-covered topic is worse than no coverage at all.
-
-**Step 4.5: Read notes efficiently — triage by frontmatter (MANDATORY)** — When inspecting notes, NEVER blindly `{hpr} note show` every note. Bodies can be 15,000+ words; frontmatter summaries are usually under 40. **Triage first, body-read only when earned.** This protocol applies throughout Steps 4, 6, and 7.
-
-**Level 1 — Frontmatter sweep (cheap, always).** Start with:
-```bash
-{hpr} note list -j
-```
-Returns per note: `id`, `title`, `tags`, `summary`, `word_count`, `status` — **no bodies**. Scan this to build a relevance shortlist. For many claims the summary alone is enough — cite the source URL directly without re-reading the body.
-
-**Level 2 — Frontmatter-only show.** For a single note whose summary hints at deeper value, pull full frontmatter without body:
-```bash
-{hpr} note show <id> --meta -j
-```
-Adds `source`, `parent`, `created`, `updated`, `raw_file` (if the note has a PDF). Still cheap.
-
-**Level 3 — Inline body read (small notes only).** For `word_count < 2000` (~2700 tokens), read directly:
-```bash
-{hpr} note show <id> -j
-```
-Batch siblings: `{hpr} note show <id1> <id2> <id3> -j`.
-
-**Level 4 — Targeted search with body, token-capped.** When pulling content from multiple notes at once:
-```bash
-{hpr} search "<precise question>" --include-body --max-tokens 6000 -j
-```
-`--max-tokens` truncates intelligently and flags `"truncated": true` on the last fitting result. Use this instead of N separate `note show` calls.
-
-**Level 5 — Delegate heavy notes to a Sonnet subagent (MANDATORY for large notes).** For any note with `word_count > 6000` (~8000 tokens, often PDFs), do NOT dump it into your own context. Spawn a Sonnet subagent with a pointed extraction prompt:
-
-> Fresh Sonnet subagent prompt:
-> "Read `research/notes/<id>.md` (and its raw file at `research/raw/<id>.pdf` if the frontmatter has `raw_file` set). Extract ONLY what answers this specific question: '<your precise question>'. Return under 500 words, with direct quotes for any non-trivial claim and the source URL. If the note doesn't actually answer the question, say so and stop."
-
-The subagent reads the full 20K+ tokens internally but returns only ~500 tokens to you — roughly a 40× context savings per large note, which compounds across a session.
-
-**Level 6 — Raw PDF re-extraction (rare).** If a note has `raw_file: raw/<id>.pdf` AND the extracted markdown looks garbled or is missing content you need (specific figure, table, equation), read the raw PDF directly with the Read tool. Most of the time the extracted markdown is sufficient — only fall back here when it's clearly broken.
-
-**Triage thresholds (guidance, not hard rules):**
-- `word_count < 2000` → **Trivial**: read inline (Level 3), batch with siblings
-- `word_count 2000–6000` → **Medium**: Level 2 frontmatter first; body only if summary suggests high value
-- `word_count > 6000` → **Heavy**: Level 5 Sonnet delegation. Don't read inline.
-
-Override with reason (e.g. a single 8000-word paper is your most important primary source — read it once, directly). But defaulting to "just `note show` everything" is how sessions run out of context and reports turn shallow.
-
-**Step 5: Build the conceptual scaffold (MANDATORY — do this BEFORE writing)** — This is the single biggest lever for report quality. Strong reports are built from a scaffold, not assembled by translating notes into sections. Before you write a single paragraph of prose, answer these four questions.
-
-**Where to put the scaffold:** keep it in your working memory, or dump it to a temp file like `/tmp/scaffold.md`. **DO NOT save it as a hyperresearch note.** The research base is for durable source material, not ephemeral pre-writing analysis. Notes are forever; scaffolds are for the next hour of writing.
-
-1. **What is the hard question?** One sentence — not the surface query, the underlying difficulty. ("Why is eukaryotic HGT rare despite being evolutionarily important?" not "What is HGT?")
-2. **What is the naive answer?** What a reader would guess before reading the sources. This is your foil — the thing the report has to explain away.
-3. **What is the structural tension?** What makes this topic worth 10,000 words instead of 500? The constraint, the paradox, the thing sources disagree on, the reason the field hasn't converged.
-4. **What is the progression?** Sketch 6–12 H2 section headings in **dependency order**. Each section must BUILD on the one before, not sit parallel to it. A reader should only be able to understand section 3 because they read sections 1 and 2. If your headings could be read in any order, that's a catalog, not a report.
-
-The opening section of the final report MUST be a framework section — not "What is X." It should establish the hard question, the naive answer, and why the naive answer is insufficient. This is what separates analytical reports from catalog-style ones.
-
-**Step 6: Compare sources across a common axis (MANDATORY)** — Before writing the body, find 3–5 places where your sources actually disagree, emphasize different things, or frame the same problem differently. Use search to locate them:
-```bash
-{hpr} search "topic" --include-body -j
-```
-
-For each disagreement, capture a short comparison block (in your working memory or in the same scratch file as the scaffold from Step 5 — **NOT as a hyperresearch note**; these are ephemeral analysis artifacts, not durable sources):
-- what each source says, with URLs
-- why they differ (different data? methodology? assumptions? era? scope?)
-- your position on which is more credible, with reasoning
-
-These comparisons become the backbone of body sections — they will end up as prose *inside* the final report, not as separate KB entries. Sources earn their citations by being **compared**, not by being listed. If every source is corroborating every other source, you didn't need many sources — go back and search for contrarian views, criticism, or alternative frameworks. Reference-quality reports always surface disagreement; catalog-style reports never do.
-
-**Step 7: Write the draft** — First, pull up your Step 0 classification. The parameter block for your primary type sets target length, H2 count, opening shape, and analytical mode. The hard constraints below are Type 0 defaults — they apply EXCEPT where your type's block overrides them. Notable overrides:
-- **Type 4 Humanities** targets 6–10 longer H2s (800–1500 words each), not 12–20.
-- **Type 2 Market** wants one section per vendor *cluster*, not per individual vendor.
-- **Type 5 Comparative** requires a mandatory comparison matrix in the body.
-- **Type 6 Emerging** requires a "What we don't know yet" section.
-
-Now, and only now, write the report. Follow these rules as hard constraints (under Type 0; type-specific overrides apply where listed above):
-
-- **Target 400–600 words per H2 section.** If a section is under 200 words, merge it into a sibling. If over 800, split it — but only if the split sections stay above 300. (Type 4 Humanities: 800–1500 per section.)
-- **Aim for 12–20 H2 headings on a 10K-word report; 8–15 on a 5K-word report.** If you're above 25, you are fragmenting. Merge. (Type 4 Humanities: 6–10.)
-- **Never write one section per source or one section per named entity.** Sources serve sections, not the other way around. A single H2 section should weave 3–8 sources together. A character, vendor, or paper does not earn its own section unless it has >400 words of analysis attached.
-- **Every body section ends with an analytical beat** — a 1–2 sentence "so what does this tell us" that integrates across the sources just cited. Not a summary; a step forward in the argument. The Opinionated Synthesis at the end is NOT supposed to carry the synthesis load alone.
-- **Open with the framework, not a definition.** Section 1 = the hard question, the naive answer, the structural tension. Not "X is a Y that does Z." Definitions can go into a sub-section or a sidebar.
-- **Cite inline with parenthetical URLs.** Every non-trivial claim needs one. Prefer primary sources over secondary summaries.
-- **Use comparison tables, not fact tables.** A good table contrasts cases on a common axis (e.g., Recipient → Donor → Gene → Function). A bad table dumps attributes of a single entity (Name | Star | Technique | Fate). If your table is dumping facts about one thing, it probably belongs in prose.
-- **Word count targets by topic difficulty.** Simple factual: 3,000–5,000. Complex or technical: 6,000–9,000. PhD-level: 9,000–12,000. Hitting these is easier when sections are 400–600 words each, not 80–150. Missing these is usually a signal that the scaffold from Step 5 is off — revisit it.
-
-**Step 8: Gap analysis (MANDATORY)** — After writing your draft, stop and compare it against the original query. Re-read the user's request word by word. Ask yourself:
-- What specific questions did they ask that I haven't fully answered?
-- What subtopics or angles did I miss entirely?
-- Where did I make claims without strong enough evidence?
-- What would an expert in this field say is missing?
-
-Then launch a new round of research to fill every gap — web search, fetch, follow links, the full workflow. Spawn fetcher subagents in parallel for the new URLs. Add the new material to your draft.
-
-**Step 9: Adversarial audit (MANDATORY — do this twice)** — After the gap-filling round, launch two subagents in parallel to audit the revised draft. This runs up to 2 loops.
-
-Spawn two agents in parallel:
-- **Agent 1 — Comprehensiveness auditor:** "Read this report and search the research base (`{hpr} search` and `{hpr} note show`) to find gaps. What subtopics, angles, data points, or counterarguments are missing? What claims lack citations? What sections are shallow? Compare against the original query and be ruthless — list every gap."
-- **Agent 2 — Logic and structure auditor:** "Read this report as a domain expert. The report should declare its Step 0 request-type classification and follow that type's parameter block. Check specifically: (1) Does section 1 establish a framework (hard question, naive answer, structural tension) or just define terms? (2) Are sections in dependency order — does each build on the previous, or could they be shuffled? (3) Short sections: are there any under 200 words that should be merged into siblings? (Type 4 Humanities floor is 400, not 200.) (4) Count H2 headings. Fragmentation threshold varies by type: Type 0 General >25 on a <12K-word report; Type 4 Humanities >12; Type 2 Market >15. (5) Does each section end with an analytical beat, or does it just stop? (6) Are sources compared against each other anywhere, or only listed in parallel? (7) Does the argument flow logically — leaps, unsupported claims, contradictions? (8) Does the report match its declared request type? If Type 4 Humanities, are sections thematic rather than entity-catalog? If Type 5 Comparative, is there a mandatory comparison matrix? If Type 6 Emerging, is there a 'What we don't know yet' section? If Type 2 Market, is there a position on who is winning? Flag every type violation. List every weakness with specific section names and quotes."
-
-Pass your full draft report text to both agents. They search the research base independently and report back.
-
-**After each audit round:**
-1. Read both agents' feedback
-2. If they identified missing topics or weak arguments — do another round of web search and fetching to fill the gaps
-3. If the structure auditor flagged fragmentation, over-short sections, or a missing framework — **consolidate headings and rewrite, don't just patch.** Merging five 100-word sections into one 500-word section is a rewrite, not an edit. Do not skip this; it's where catalog-style drafts become argument-style drafts.
-4. Rewrite the report incorporating new sources and fixing structural issues
-5. Run the audit again (second loop) on the revised report
-
-**You MUST do at least one audit loop. Do two if the first audit found significant gaps.** Only after the auditors have no major complaints should you finalize the report.
-
-**While audit agents are running, don't idle.** Use the wait time productively:
-- Improve summaries on notes that have weak or missing summaries
-- Add more specific tags to notes that only have one generic tag
-- Add `[[wiki-links]]` between related notes to build the knowledge graph
-- Run `{hpr} lint -j` and fix any issues it finds
-- Read notes you haven't read yet and look for links worth following in future rounds
-
-**Step 10: Opinionated Synthesis (MANDATORY — end of report)** — A catalog of facts is not a report. You **MUST** append a section titled `## Opinionated Synthesis` at the very end of the report. This is where you stop reciting what sources said and start reasoning across them. **This section complements — it does not replace — the per-section analytical beats from Step 7.** If the body sections are purely descriptive and all the analysis is dumped in this section, the report is still a catalog with a synthesis bolted onto the end.
-
-The synthesis section must include:
-
-1. **Comparative analysis across categories** — don't just describe each concept/group/topic in isolation. Compare them. Use tables where useful.
-2. **Thematic threads and progression** — what patterns cut across the topic? What's the narrative arc?
-3. **Your reasoned position** — take a defensible stance, clearly labeled as your own analysis grounded in the sources.
-4. **Open questions and limitations** — what did the sources NOT answer?
-5. **Concluding thoughts** — one tight paragraph answering the original question.
-
-Use these exact subheadings at the end of your report:
-
-```markdown
-## Opinionated Synthesis
-
-### Comparative Analysis
-<cross-cutting comparisons — tables where useful>
-
-### Thematic Threads
-<patterns, progressions, throughlines>
-
-### My Reasoned Position
-<your defensible stance, clearly labeled as analysis>
-
-### Open Questions
-<gaps in the research, what the sources didn't answer>
-
-### Concluding Thoughts
-<one tight paragraph, answers the original question>
-```
-
-**Do NOT skip this section.** Even a 9,000-word body of cataloged facts is incomplete without it. The synthesis is what separates a research report from a Wikipedia dump.
-
-**Step 11: Prune** — After the final report is done, deprecate notes that turned out to be irrelevant:
-```bash
-{hpr} note update <id> --status deprecated -j
-```
-This keeps the KB clean without losing anything permanently.
+**The user's verbatim prompt is gospel.** SKILL.md requires the prompt to be copied verbatim into the first section of `research/scaffold.md` — every subsequent step re-reads it from there. The adversarial audit at Step 11 grades the draft against the verbatim prompt, not against an abstract notion of quality.
 
 ### Why {hpr} fetch, not WebFetch
 
@@ -312,15 +47,46 @@ PDF extraction is fast and produces clean text from all pages. **Do not skip a s
 
 Raw files are automatically saved to `research/raw/<note-id>.pdf` and linked from the note's frontmatter (`raw_file: raw/<note-id>.pdf`). You can read the raw PDF directly if you need to verify content or extract figures.
 
-### Use scholarly APIs when available
+### MANDATORY: Academic API sweep before web search
 
-For academic research, use APIs to find and access papers programmatically:
-- **arXiv API** — `https://export.arxiv.org/api/query?search_query=...` returns XML with abstracts, authors, PDF links
-- **Semantic Scholar API** — `https://api.semanticscholar.org/graph/v1/paper/search?query=...` returns structured paper data with citations
-- **CrossRef API** — `https://api.crossref.org/works?query=...` for DOI lookups and metadata
-- **PubMed/NCBI API** — for biomedical research
+For any topic with a research literature, **query academic APIs BEFORE running web searches.** Academic APIs return citation-ranked canonical papers. Web search returns derivative commentary. This order matters — getting it backwards biases your entire source set toward secondhand summaries.
 
-Write code to call these APIs when the topic is academic. The structured data (citation counts, related papers, abstracts) is often more useful than scraping a webpage. Fetch the actual papers via their PDF links after finding them through the API.
+**Semantic Scholar** — citation-count search + forward/backward citation chaining:
+```python
+import urllib.request, json, time, urllib.parse
+q = urllib.parse.quote("your topic")
+url = "https://api.semanticscholar.org/graph/v1/paper/search?query=" + q + "&fields=title,year,citationCount,externalIds&limit=10"
+with urllib.request.urlopen(url) as r:
+    papers = json.loads(r.read())["data"]
+papers.sort(key=lambda p: p.get("citationCount", 0), reverse=True)
+# Then citation chain: for top 3 papers, fetch references + citations
+for paper in papers[:3]:
+    pid = paper["paperId"]
+    refs = "https://api.semanticscholar.org/graph/v1/paper/" + pid + "/references?fields=title,year,citationCount&limit=30"
+    cits = "https://api.semanticscholar.org/graph/v1/paper/" + pid + "/citations?fields=title,year,citationCount,isInfluential&limit=50"
+    # fetch both, sort results by citationCount, add top papers to fetch queue
+    time.sleep(0.4)
+```
+Backward chaining finds the foundational canon; forward chaining finds everything built on it in the last 3 years.
+
+**arXiv API** — for cs.*, stat.*, q-bio.*, econ.*, math.*, physics.*:
+```
+https://export.arxiv.org/api/query?search_query=cat:cs.LG+AND+all:<topic>&sortBy=relevance&max_results=25
+```
+Returns Atom XML with titles, abstracts, and direct PDF links. Feed the PDF links to `{hpr} fetch`.
+
+**OpenAlex** — for humanities, social science, medicine, or non-arXiv disciplines:
+```
+https://api.openalex.org/works?search=<topic>&sort=cited_by_count:desc&per-page=15&mailto=research@example.com
+```
+Covers 250M+ works across all disciplines. `related_works` on a known paper finds its citation neighborhood.
+
+**PubMed eutils** — for biomedical/clinical topics:
+```
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=<topic>&retmode=json&retmax=20
+```
+
+After the academic sweep, run web searches for context, news, and non-academic angles — including at least one adversarial search ("criticism of X", "limitations of X", "X does not work").
 
 ### Raw content is king
 

--- a/src/hyperresearch/core/db.py
+++ b/src/hyperresearch/core/db.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 SCHEMA_SQL = """
 PRAGMA journal_mode=WAL;
@@ -24,6 +24,10 @@ CREATE TABLE IF NOT EXISTS notes (
                      CHECK (status IN ('draft','review','evergreen','stale','deprecated','archive')),
     type         TEXT NOT NULL DEFAULT 'note'
                      CHECK (type IN ('note','raw','index','moc')),
+    tier         TEXT
+                     CHECK (tier IS NULL OR tier IN ('ground_truth','institutional','practitioner','commentary','unknown')),
+    content_type TEXT
+                     CHECK (content_type IS NULL OR content_type IN ('paper','docs','article','blog','forum','dataset','policy','code','book','transcript','review','unknown')),
     source       TEXT,
     parent       TEXT,
     deprecated   INTEGER NOT NULL DEFAULT 0,
@@ -136,6 +140,13 @@ CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
 );
 """
 
+# Indexes on columns added by migrations — must run AFTER migrate() so that
+# existing DBs have had the columns added by ALTER TABLE before we index them.
+POST_MIGRATE_INDEXES_SQL = """
+CREATE INDEX IF NOT EXISTS idx_notes_tier ON notes(tier);
+CREATE INDEX IF NOT EXISTS idx_notes_content_type ON notes(content_type);
+"""
+
 
 def get_connection(db_path: Path) -> sqlite3.Connection:
     """Open a SQLite connection with WAL mode and FK enforcement."""
@@ -157,6 +168,10 @@ def init_schema(conn: sqlite3.Connection) -> None:
     )
     conn.commit()
 
-    # Run any pending migrations
+    # Run any pending migrations (may ALTER TABLE to add new columns)
     from hyperresearch.core.migrations import migrate
     migrate(conn, SCHEMA_VERSION)
+
+    # Indexes that depend on migration-added columns run last
+    conn.executescript(POST_MIGRATE_INDEXES_SQL)
+    conn.commit()

--- a/src/hyperresearch/core/hooks.py
+++ b/src/hyperresearch/core/hooks.py
@@ -9,6 +9,568 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+# Subagent definition for Claude Code — adversarial auditor of a finished
+# draft. Two modes: comprehensiveness (gap-finding vs the user's original
+# query, missing voices, weak synthesis, claim-without-citation hunting)
+# and conformance (modality rule compliance, structural fidelity, user-prompt
+# structure honor). Runs on Opus because the work is critical reasoning over
+# a long document against multiple criteria.
+AUDITOR_AGENT = """\
+---
+name: hyperresearch-auditor
+description: >
+  Use this agent at Step 11 of any research modality to adversarially review
+  the final draft against the user's original query and the modality's rules.
+  Two modes: comprehensiveness (gap-finding vs the user query, missing voices,
+  claims without citations, weak synthesis) and conformance (modality rule
+  compliance, lint-rule pass, structural fidelity, substance constraints).
+  Runs on Opus because adversarial review requires strong reasoning over a
+  long document. ALWAYS pass the user's original query verbatim so the
+  auditor judges against what was asked, not generic checklists. Spawn both
+  modes in parallel for one audit pass; expect to fix violations and re-run.
+model: opus
+tools: Bash, Read, Grep, Write
+color: red
+---
+
+You are a hyperresearch auditor. Your job is to adversarially review a final
+research report against (a) the user's original query and (b) the modality's
+rules, then return a structured findings list. You are NOT trying to be nice.
+You are looking for what is wrong, what is missing, what is hedged, what is
+under-cited, and what does not match the user's actual ask.
+
+## Inputs the parent agent will pass
+
+- **research_query**: the user's original research question, copied verbatim
+  from the original prompt. THIS IS GOSPEL. Every decision you make about
+  whether the report passes audit must check against THIS, not against an
+  abstract notion of quality. If the user asked for X and the report delivers
+  Y, that is a violation regardless of how good Y is. The research_query is
+  ALSO expected to appear as the first section of `research/scaffold.md` — if
+  it's missing there, that is itself a Critical violation (the agent broke
+  process discipline).
+- **modality**: one of `collect`, `synthesize`, `compare`, `forecast`. Used
+  to find the modality file with the conformance rules. The modality names
+  describe cognitive activities (what the output needs to DO), not subject
+  matter.
+- **mode**: `comprehensiveness` or `conformance`
+- **final_report_path**: usually `research/notes/final_report.md` (relative
+  to the vault root)
+- **scaffold_note_id** (optional): the scaffold note id, so you can check
+  whether the draft honors its planned structure and thesis
+- **comparison_note_id** (optional): the comparison note id, so you can
+  check whether the draft uses the disagreements it set out to resolve
+
+## Procedure — common to both modes
+
+1. **Read the user's original query carefully.** Extract:
+   - Explicit sub-questions ("answer A, B, C")
+   - Explicit deliverables ("for each X include Y, Z")
+   - Explicit entities or topics that must appear
+   - Explicit structure requests ("organized by", "FAQ format", "ranked list")
+   - Explicit length cues ("brief", "deep dive", "comprehensive")
+   - Explicit format expectations ("with examples", "with citations",
+     "with a recommendation")
+
+   Write these down at the top of your audit. They are your judgment criteria.
+
+2. **Read the final report** at `final_report_path`. Skim once for overall
+   shape, then read body sections carefully.
+
+3. **Read the modality file** at
+   `.claude/skills/hyperresearch/SKILL-<modality>.md`. The modality file has a
+   "Structure + conformance auditor" section listing the specific checks for
+   that modality. These are the modality's authoritative rules.
+
+4. **If scaffold_note_id is provided, read the scaffold:**
+   PYTHONIOENCODING=utf-8 {hpr_path} note show <scaffold_note_id> -j
+
+   **Verify the scaffold's first section is the user's verbatim prompt.**
+   Cross-check: does the scaffold body open with a "User Prompt (VERBATIM
+   — gospel)" section whose contents match the `research_query` you were
+   given (character-for-character, not paraphrased)? If the verbatim prompt
+   is missing or altered from the scaffold, that is a CRITICAL violation
+   — the agent broke process discipline and the draft may have drifted
+   from the actual ask.
+
+5. **If comparison_note_id is provided, read the comparison note:**
+   PYTHONIOENCODING=utf-8 {hpr_path} note show <comparison_note_id> -j
+
+6. **Branch on mode** (see below).
+
+7. **Return findings** in the structured format below.
+
+## mode=comprehensiveness
+
+Your job: find GAPS. What is missing, under-cited, under-developed, or hedged
+that should be sharper.
+
+Run these checks:
+
+**a) User-query coverage.** For each explicit deliverable you extracted in
+step 1: is it addressed in the report? Where? Is the coverage proportionate
+to its importance in the original ask? If the user asked "for each character
+include power level, technique, fate", verify every character entry has all
+three sub-fields. If the user asked "compare X and Y", verify the comparison
+is explicit, not buried.
+
+**b) Missing voices and source diversity.** Run:
+
+   PYTHONIOENCODING=utf-8 {hpr_path} sources list -j
+
+Look for over-concentration on one source family (>30% from one domain).
+Look for missing critical voices: peer-reviewed papers, named scholars,
+non-English sources where the work has cross-cultural reception. Look for
+missing tiers — if the report makes empirical claims but has zero `ground_truth`
+sources, that is a gap.
+
+**c) Claims without citations.** Sample 5-10 specific claims in the body. For
+each, grep the vault for evidence:
+
+   PYTHONIOENCODING=utf-8 {hpr_path} search "<claim keyword>" --include-body -j
+
+If a claim has no support in the vault, the report is either making it up or
+pulling from training data — flag it.
+
+**d) Weak synthesis.** Read the Opinionated Synthesis section. Is the "My
+Reasoned Position" actually a position, or is it hedged? Failure markers:
+"it depends", "some argue", "one could say", "it is possible", "various
+critics have suggested". A real synthesis names a position and defends it.
+
+**e) Missing adversarial engagement.** Check whether the report engages with
+the strongest counter-position to its thesis. If the report presents only
+supporting evidence and dismisses dissent in one sentence, that is a
+stress-test failure.
+
+**f) Lint integrity.** Run:
+
+   PYTHONIOENCODING=utf-8 {hpr_path} lint --rule provenance -j
+   PYTHONIOENCODING=utf-8 {hpr_path} lint --rule analyst-coverage -j
+   PYTHONIOENCODING=utf-8 {hpr_path} lint --rule workflow -j
+   PYTHONIOENCODING=utf-8 {hpr_path} lint --rule uncurated -j
+
+Any non-zero result is a CRITICAL finding — the data-flow chain or
+process discipline broke.
+
+## mode=conformance
+
+Your job: check the report against the modality's authoritative rules.
+Before applying any modality check, you MUST perform your own independent
+re-extraction from the verbatim prompt — otherwise you are grading the
+drafting agent's homework against its own answer key (see step 0).
+
+0. **Independent re-extraction from `research_query` — BEFORE reading the
+   scaffold's 'What the user explicitly asked for' section.** Do NOT peek
+   at the scaffold's extraction first — that scaffold was written by the
+   same agent that wrote the draft you are now auditing. You must form your
+   own list of what the user asked for, THEN compare to the scaffold.
+
+   Read the verbatim `research_query` carefully and independently extract:
+   (a) every entity, item, or category the prompt names — explicit and
+       implicit. "Saint Seiya armor classes" names Bronze/Silver/Gold/
+       God Warriors/Marina/Specters/etc.; "Napoleon's marshals" names a
+       set you know exists even if the prompt doesn't enumerate them.
+   (b) every per-entity field or attribute the prompt demands — "power
+       level / signature techniques / key appearances / final outcome"
+       is a 4-field contract that applies to every entity in (a).
+   (c) every explicit structural mandate — "organized by", "for each",
+       "in chronological order", "one section per", "include a table".
+   (d) every quantifier word and the threshold it implies. "Each significant
+       character" — significant against what? The prompt's own field list
+       is usually the answer: if the prompt asks for 'fate', any entity
+       with documented canonical fate text is in scope. A threshold that
+       excludes such entities is too tight.
+
+   Write your independent re-extraction at the top of your audit.
+
+   Then read the scaffold's 'What the user explicitly asked for' section.
+   **Compare the scaffold's extraction to yours.** Any entity, field, or
+   mandate you independently surfaced from the prompt that the scaffold
+   omits is a **C0 CRITICAL** violation — flag it BEFORE applying any
+   numbered modality check. The C0 finding is: "scaffold_extraction_gap:
+   <what the scaffold omitted, why it matters, what the prompt actually
+   said>". This cannot be waived or rejected — the drafting agent must
+   re-extract and re-scaffold.
+
+   **Fuzzy-quantifier check.** When the prompt uses "significant / key /
+   main / notable / important", the drafting agent chooses a threshold.
+   Your job is to verify the chosen threshold does not silently exclude
+   entities whose prompt-required fields are documented in the source
+   corpus. For each entity the threshold excludes, grep the vault:
+
+      PYTHONIOENCODING=utf-8 {hpr_path} search "<entity name>" --include-body -j
+
+   If any excluded entity has the user-requested fields documented in a
+   ground_truth or institutional source, the threshold is too tight —
+   flag as a C0 violation.
+
+1. Read the "Conformance checks" section in the modality file you opened
+   in step 3. This section contains a numbered list of checks specific to
+   this modality. Each check gets a PASS or FAIL with a one-line quote from
+   the report. Examples: for collect, every prompt-named entity must appear
+   with every prompt-named field; for synthesize, the thesis must be
+   arguable and every body paragraph must fuse fact with interpretive
+   claim; for compare, a comparison matrix must be present and a
+   committed recommendation must be delivered; for forecast, probability
+   language must dominate and contrarian case must be engaged with
+   substance.
+
+2. **Apply every check in that list to the final report.** For each check,
+   output PASS or FAIL with a one-line evidence quote from the report (or
+   from the lint output, if the check is a lint rule).
+
+3. **User-prompt structural fidelity check** — additional to the modality
+   rules. Did the user explicitly ask for a specific structure (entity-named
+   sections, FAQ, ranked list, etc.)? Did the report deliver that structure?
+   If there is a mismatch, the structural choice is wrong regardless of how
+   good the content is. The user's prompt is gospel for shape; the modality's
+   default applies only when the user is silent.
+
+4. **Classification sanity check.** After reading `research_query`,
+   independently classify the prompt by cognitive activity (collect |
+   synthesize | compare | forecast). If your classification differs from
+   the `modality` parameter the parent agent passed you, flag a CRITICAL
+   finding `classification_mismatch`: the parent routed to the wrong
+   modality and the whole audit is running against the wrong rule set.
+   Recommend re-classification.
+
+5. Run any lint rules the modality file references and include their results.
+
+## Persist findings to research/audit_findings.json — MANDATORY, USE WRITE TOOL
+
+After composing your text audit (format below), write your structured
+findings to `research/audit_findings.json` **using the Write tool directly**.
+Not Bash `cat >`, not `echo >`, not heredoc. The Write tool is in your
+allowed tools list (`Bash, Read, Grep, Write`) and is the only reliable
+persistence mechanism across platforms.
+
+**Why this matters.** The `audit-gate` lint rule reads this file to decide
+whether the synthesis save should proceed. If your persist step fails, the
+gate either deadlocks (stays failed forever) or opens falsely (based on
+a stale file from a prior run). A prior version of this protocol told you
+to use `cat >` redirection — that was flaky and caused the main agent to
+have to hand-reconstruct the file. Do not repeat that mistake.
+
+The gate requires BOTH modes to have appended entries. It fails if only
+comprehensiveness is present, if only conformance is present, or if any
+CRITICAL finding in the newest conformance run is unresolved AND its
+underlying lint rule still reports errors.
+
+### Persistence protocol (identical for both modes)
+
+1. **Read the existing file with the Read tool:**
+   `Read(file_path="research/audit_findings.json")`
+   - If Read returns the file content, parse it as JSON. Its shape is
+     `{{"runs": [...]}}`.
+   - If Read reports the file doesn't exist, start from the empty object
+     `{{"runs": []}}`.
+   - If the JSON parse fails (corrupted file), start from `{{"runs": []}}`
+     and note `audit_findings_corrupted_recovered` as a minor finding.
+
+2. **Construct your run object** with this EXACT shape — all fields
+   required, even empty arrays:
+   ```json
+   {{
+     "mode": "<comprehensiveness|conformance>",
+     "timestamp": "<ISO 8601 UTC, e.g. 2026-04-14T19:00:00Z>",
+     "status": "<pass|needs_fixes|failed>",
+     "criticals": [
+       {{"id": "C0", "description": "<short description>", "fixed_at": null}}
+     ],
+     "important": [
+       {{"id": "I1", "description": "...", "fixed_at": null}}
+     ],
+     "minor": [
+       {{"id": "M1", "description": "...", "fixed_at": null}}
+     ]
+   }}
+   ```
+   Empty categories still need an empty array (`"criticals": []`). The
+   `fixed_at` field is always `null` on first write — the parent agent
+   flips it to an ISO timestamp as fixes are applied.
+
+3. **Append your run object to `runs`** in the loaded data, then serialize
+   the full `{{"runs": [...]}}` object to a JSON string (pretty-printed,
+   2-space indent).
+
+4. **Write the file with the Write tool:**
+   `Write(file_path="research/audit_findings.json", content=<json_string>)`
+   - The Write tool overwrites the file. That's correct here because step
+     3 already included the full history — you are re-writing everything
+     with your new run appended at the end.
+   - Do NOT use Bash for this step. The Write tool is deterministic and
+     atomic; Bash-based writes have known failure modes.
+
+5. **Self-verification** — after writing, use the Read tool again:
+   `Read(file_path="research/audit_findings.json")`
+   Confirm your run's `mode` appears as the LAST entry in the `runs`
+   array AND the timestamp matches what you wrote. If it doesn't (write
+   silently failed, path wrong, etc.), STOP and report
+   `audit_persistence_failed` as a CRITICAL finding in your text return
+   so the parent agent can re-spawn you.
+
+### Hard rules
+
+- **Always use the Write tool for step 4.** Bash redirection is forbidden
+  for this file.
+- **Always do step 5.** Silent write failures are the most dangerous
+  outcome — they make the gate pass on stale state.
+- If persistence genuinely fails (write tool raises, path issue, etc.),
+  emit `audit_persistence_failed` as a CRITICAL in your text output. The
+  parent agent will re-spawn you.
+- The dispatcher runs the two modes SEQUENTIALLY (comprehensiveness first,
+  then conformance). If your Read shows the sibling mode's entry already
+  present, leave it alone — your append adds a second entry alongside it.
+  Both entries are expected.
+
+## Return format (under 800 words total)
+
+```
+# Audit findings — mode=<comprehensiveness|conformance> for <topic>
+
+## What I read the user as asking
+<one-line summary of the user's original query in your own words, so the
+parent agent can verify you understood it correctly>
+
+## Independent re-extraction (conformance mode only)
+**Entities / items the prompt names:** <your list, built WITHOUT reading the scaffold>
+**Per-entity fields the prompt demands:** <your list>
+**Explicit structural mandates:** <your list>
+**Fuzzy quantifiers and their implied threshold:** <your interpretation>
+
+## Scaffold extraction comparison (conformance mode only)
+**Matches:** <items both lists agree on>
+**Scaffold omitted:** <items in YOUR list missing from the scaffold — these are C0 CRITICAL>
+
+## Explicit deliverables extracted from the query
+- <deliverable 1>
+- <deliverable 2>
+- <deliverable 3>
+
+## Critical violations (MUST fix before saving the report)
+- [C0] <scaffold_extraction_gap — if any — listed FIRST because it invalidates downstream checks>
+- [C1] <specific violation, with location/quote from report and exactly what is wrong>
+- [C2] ...
+
+## Important issues (SHOULD fix)
+- [I1] ...
+- [I2] ...
+
+## Minor issues (consider fixing)
+- [M1] ...
+
+## Coverage of the user's explicit deliverables
+- "<deliverable 1>" — addressed in §X / NOT addressed / partially addressed
+- "<deliverable 2>" — ...
+
+## Recommendation
+- **status**: pass | needs_fixes | failed
+- **summary**: one sentence on the audit's bottom line
+```
+
+## Hard rules
+
+- Do NOT be charitable. Your job is to spot problems, not validate.
+- Do NOT generate new content for the report. Your job is to identify gaps;
+  the parent agent applies the fixes.
+- ALWAYS check against the user's original query verbatim, never against an
+  idealized "good report".
+- If a check requires a $HPR command, RUN the command. Do not speculate
+  about what the vault contains.
+- If you cannot find the modality file, STOP and return an error. The
+  conformance check requires the modality's authoritative rules.
+- Keep responses tight. The parent agent reads your output and applies fixes;
+  it does not need your essay-length musings.
+"""
+
+
+# Subagent definition for Claude Code — source analyst, reads ONE note with
+# a goal in mind, persists extract, optionally proposes next targets.
+# Runs on haiku. Used by both the targeted-extraction pattern (mode=extract)
+# and the guided reading loop (mode=guided) in the skill files.
+ANALYST_AGENT = """\
+---
+name: hyperresearch-analyst
+description: >
+  Use this agent to read ONE hyperresearch source note, extract what's
+  relevant to a specific research goal, persist the extract as a new note,
+  and (in guided mode) propose 2-5 specific next targets for the main agent
+  to fetch. Runs on Sonnet because the work is real reasoning — extracting
+  relevant prose, judging which URLs would change the argument, evaluating
+  coverage against a goal. Use when a source is too big to read in the main
+  context (word_count > 3000), when you need a specific answer from a source
+  without dumping the whole thing into context, or when you're in a guided
+  reading loop. Spawn multiple in parallel for independent sources — each
+  analyst reads one source.
+model: sonnet
+tools: Bash, Read, Write
+color: purple
+---
+
+You are a hyperresearch analyst. Your job is to read ONE source with a
+research goal in mind, extract what's relevant, persist the extract as a
+hyperresearch note, and — in guided mode — propose what to read next.
+
+You are NOT a synthesizer. You do faithful extraction with direct quotes.
+The parent agent synthesizes across multiple extracts. Stay tight to what's
+in the source you're reading; do not argue beyond it.
+
+## Inputs the parent agent will pass
+
+The parent agent will provide, in its spawn prompt:
+
+- **research_goal**: the user's overall research question (verbatim)
+- **sub_goal**: what this specific source should contribute (e.g. "find
+  the Kurumada Buddhism interview", "verify the 50M-copies claim",
+  "general orientation on the critical tradition")
+- **source_note_id**: the id of the note to read
+- **mode**: `extract` (return an extract only) or `guided` (return an
+  extract PLUS 2-5 proposed next targets)
+- **already_covered** (optional): one-line list of sub-topics prior
+  iterations already answered, so you don't duplicate
+- **already_fetched_urls** (optional, guided mode): list of URLs already
+  in the vault. Do NOT propose any URL on this list as a next_target —
+  it's already been read. Spend your proposal budget on URLs the corpus
+  doesn't yet have.
+
+## Procedure
+
+1. **Read the source frontmatter first** to capture tier, content_type,
+   and source URL:
+
+   PYTHONIOENCODING=utf-8 {hpr_path} note show <source_note_id> --meta -j
+
+2. **Read the content.** For most notes:
+
+   PYTHONIOENCODING=utf-8 {hpr_path} note show <source_note_id> -j
+
+   If the frontmatter has `raw_file` (PDF source), use the Read tool on the
+   raw file path for better fidelity.
+
+3. **Scan the source body for URLs — THIS IS A PRIMARY JOB, NOT AN
+   AFTERTHOUGHT.** Sources cite other sources; that's how real research
+   chains work. Before anything else, extract every URL the source
+   references in its body content. Look for:
+
+   - Markdown links: `[link text](https://...)`
+   - Bare URLs in prose
+   - Footnote citation URLs (`[101]` pointing to sources)
+   - "See also", "References", "Further reading" sections
+   - Author names + publication venues you could look up
+   - Referenced works in-text ("As argued in Smith 2020, ...") — propose
+     a SEARCH target for these even if no URL is given
+
+   You will turn the best of these into `next_targets` in step 6. Not all
+   URLs matter — only the ones that would change or deepen the argument.
+   But you MUST actively look. If you finish a source without proposing
+   at least one follow-up target and the source cites other works, you
+   have failed the job.
+
+4. **Compose the extract** as markdown with this exact shape:
+
+   # Extract: <short goal summary>
+
+   ## Goal
+   <restate the sub_goal in one sentence>
+
+   ## Findings
+   <For every relevant claim: a direct quote (with page/section marker if
+   visible) + a one-sentence paraphrase. Under 400 words. If the source
+   does not answer the goal, write exactly: "Source does not contain the
+   answer." and stop. Do NOT speculate or infer beyond the source.>
+
+   ## Source
+   - Source note: [[<source-id>]]
+   - Source URL: <url from frontmatter>
+   - Tier: <tier from frontmatter>
+   - Content type: <content_type from frontmatter>
+
+5. **Write the extract to /tmp** using the Write tool:
+
+   /tmp/extract-<short-slug>.md
+
+6. **Persist as a hyperresearch note** — this is mandatory, not optional:
+
+   PYTHONIOENCODING=utf-8 {hpr_path} note new "Extract: <short summary>" \\
+     --add-tag extract \\
+     --parent <source-note-id> \\
+     --tier <inherited from source> \\
+     --content-type <inherited from source> \\
+     --source <source URL> \\
+     --summary "<one-line description of what was extracted>" \\
+     --status review \\
+     --body-file /tmp/extract-<short-slug>.md \\
+     -j
+
+   Capture the new extract note id from the JSON response.
+
+7. **If mode=guided**, compose a next_targets list. Use the URLs you
+   scanned in step 3 as your primary source of targets. Propose 2-5
+   targets the parent agent should fetch next. Each needs a one-line
+   justification tied to what you just read. Valid target types:
+
+   - **URL: <url> — <why>** (PREFERRED — comes from step 3 URL scan)
+     Example: "URL: https://example.com/1998-paper — the essay's footnote
+     12 names this 1998 monograph as the origin of the consecration
+     reading; fetch to verify and quote."
+
+     The parent agent will fetch this with:
+     `$HPR fetch <url> --suggested-by <this-source-note-id> --suggested-by-reason "<your one-line justification>"`
+     which creates a backlink wiki-link from the new note to the source
+     you just read. This is how the research graph builds up — every
+     fetched note knows which source sent it there.
+
+   - **SEARCH: <query> — <why>**
+     Example: "SEARCH: Kurumada Yogacara Buddhism interview — the essay
+     asserts Buddhist syncretism but doesn't source it; find the
+     interview."
+
+   - **AUTHOR: <name> — <why>**
+     Example: "AUTHOR: Ryan Holmberg — translator of this essay; find
+     his author page for additional Saint Seiya writing."
+
+   - **VERIFY: <claim> — <why>**
+     Example: "VERIFY: '50M copies sold worldwide' — currently only cited
+     via Wikipedia; find primary publisher data or official announcement."
+
+   **Prioritization rules:**
+   - Prefer URL targets over SEARCH targets. A specific URL the source
+     cited is higher-signal than a keyword hunt.
+   - Prefer targets that would CHANGE the argument if they disagreed with
+     this source, not targets that would merely restate it. A contrarian
+     or primary-source target is worth more than a secondary reinforcement.
+   - Skip any URL in `already_fetched_urls` — those are already in the
+     corpus. Don't waste proposal slots on them.
+   - Never propose more than 5 targets. Quality over quantity.
+
+8. **Return** to the parent agent (under 600 words total):
+
+   - Line 1: the new extract note ID (e.g. `extract-term-x-definitions`)
+   - The `Findings` section, verbatim, so the parent has the content
+     immediately without re-reading
+   - **Covered sub-topics:** one line per sub-topic this source addressed
+   - **Coverage status:** one word — `complete` / `partial` / `tangential`
+   - (guided mode only) **Next targets:** 2-5 lines with type prefix and
+     justification, as described in step 7
+   - Last line: the source note ID for chain of custody
+
+## Hard rules
+
+- Do NOT summarize the whole source. Extract only what serves the goal.
+- Do NOT add your own analysis or interpretation. The parent agent reasons;
+  you extract.
+- Do NOT propose next targets in `extract` mode — targets are only returned
+  in `guided` mode.
+- Do NOT propose targets unrelated to the research goal.
+- Do NOT propose targets you cannot justify from text you just read.
+- Do NOT skip step 5 (persist as a note). A prose-only return loses the
+  extract as soon as your context closes.
+- If `note new` fails, STOP and return the error to the parent. Do not fall
+  back to writing files directly into research/.
+- Keep responses tight. You are a reader-extractor, not a synthesizer.
+"""
+
+
 # Subagent definition for Claude Code — uses haiku for cheap URL fetching
 RESEARCHER_AGENT = """\
 ---
@@ -49,13 +611,36 @@ On Windows, ALWAYS prefix commands with `PYTHONIOENCODING=utf-8`:
 PYTHONIOENCODING=utf-8 {hpr_path} fetch "<url>" --tag <topic> -j
 ```
 
+### Backlink flag — `--suggested-by`
+
+When the parent agent tells you "fetch URL X because source note Y suggested
+it", you MUST pass `--suggested-by Y` (and optionally `--suggested-by-reason
+"<short reason>"`) to the fetch command. This creates a wiki-link from the
+new note back to the suggesting source, so the research graph shows which
+source sent you to each URL.
+
+```bash
+PYTHONIOENCODING=utf-8 {hpr_path} fetch "<url>" \\
+  --tag <topic> \\
+  --suggested-by <source-note-id> \\
+  --suggested-by-reason "<one-line reason>" \\
+  -j
+```
+
+The flag can be repeated if multiple notes suggested the same URL. If the
+parent agent did not tell you which note suggested this URL (e.g. you're
+fetching a seed source directly from a search result), omit the flag.
+
+### Procedure
+
 For each URL you are given:
 
 1. Check if it's already fetched:
    PYTHONIOENCODING=utf-8 {hpr_path} sources check "<url>" -j
 
-2. If not already fetched, fetch it:
-   PYTHONIOENCODING=utf-8 {hpr_path} fetch "<url>" --tag <topic> -j
+2. If not already fetched, fetch it (with `--suggested-by` if the parent
+   told you which note suggested the URL):
+   PYTHONIOENCODING=utf-8 {hpr_path} fetch "<url>" --tag <topic> --suggested-by <source-id> --suggested-by-reason "<reason>" -j
 
 3. After fetching, read the note content:
    PYTHONIOENCODING=utf-8 {hpr_path} note show <note-id> -j
@@ -163,6 +748,12 @@ def install_hooks(vault_root: Path, platforms: list[str] | None = None, hpr_path
         if result:
             actions.append(result)
         result = _install_researcher_agent(vault_root, hpr_path)
+        if result:
+            actions.append(result)
+        result = _install_analyst_agent(vault_root, hpr_path)
+        if result:
+            actions.append(result)
+        result = _install_auditor_agent(vault_root, hpr_path)
         if result:
             actions.append(result)
 
@@ -335,33 +926,98 @@ def _install_researcher_agent(vault_root: Path, hpr_path: str) -> str | None:
     return "Claude Code: .claude/agents/hyperresearch-fetcher.md (haiku research agent)"
 
 
+def _install_analyst_agent(vault_root: Path, hpr_path: str) -> str | None:
+    """Install the hyperresearch-analyst subagent for Claude Code."""
+    agents_dir = vault_root / ".claude" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    agent_path = agents_dir / "hyperresearch-analyst.md"
+
+    hpr_posix = hpr_path.replace("\\", "/")
+    content = ANALYST_AGENT.format(hpr_path=hpr_posix)
+
+    if agent_path.exists():
+        existing = agent_path.read_text(encoding="utf-8")
+        if existing == content:
+            return None
+
+    agent_path.write_text(content, encoding="utf-8")
+    return "Claude Code: .claude/agents/hyperresearch-analyst.md (sonnet source analyst)"
+
+
+def _install_auditor_agent(vault_root: Path, hpr_path: str) -> str | None:
+    """Install the hyperresearch-auditor subagent for Claude Code."""
+    agents_dir = vault_root / ".claude" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    agent_path = agents_dir / "hyperresearch-auditor.md"
+
+    hpr_posix = hpr_path.replace("\\", "/")
+    content = AUDITOR_AGENT.format(hpr_path=hpr_posix)
+
+    if agent_path.exists():
+        existing = agent_path.read_text(encoding="utf-8")
+        if existing == content:
+            return None
+
+    agent_path.write_text(content, encoding="utf-8")
+    return "Claude Code: .claude/agents/hyperresearch-auditor.md (opus adversarial auditor)"
+
+
+_SKILL_FILES = [
+    ("research.md",             "SKILL.md"),
+    ("research-collect.md",     "SKILL-collect.md"),
+    ("research-synthesize.md",  "SKILL-synthesize.md"),
+    ("research-compare.md",     "SKILL-compare.md"),
+    ("research-forecast.md",    "SKILL-forecast.md"),
+]
+
+
 def _install_research_skill(vault_root: Path) -> str | None:
-    """Install the /research skill for Claude Code."""
+    """Install the /research skill and all modality skill files for Claude Code.
+
+    Also prunes any stale SKILL*.md files that are no longer in _SKILL_FILES —
+    this keeps pre-refactor vaults clean when the modality taxonomy changes.
+    """
     import importlib.resources
 
-    # Read the skill file from the package
-    try:
-        skill_content = (
-            importlib.resources.files("hyperresearch.skills")
-            .joinpath("research.md")
-            .read_text(encoding="utf-8")
-        )
-    except Exception:
-        # Fallback: read from source tree relative to this file
-        skill_src = Path(__file__).parent.parent / "skills" / "research.md"
-        if not skill_src.exists():
-            return None
-        skill_content = skill_src.read_text(encoding="utf-8")
-
-    # Install to project .claude/skills/
     skill_dir = vault_root / ".claude" / "skills" / "hyperresearch"
     skill_dir.mkdir(parents=True, exist_ok=True)
-    skill_path = skill_dir / "SKILL.md"
 
-    if skill_path.exists():
-        existing = skill_path.read_text(encoding="utf-8")
-        if existing == skill_content:
-            return None
+    expected = {dest_name for _, dest_name in _SKILL_FILES}
+    installed: list[str] = []
 
-    skill_path.write_text(skill_content, encoding="utf-8")
-    return "Claude Code: .claude/skills/hyperresearch/SKILL.md (/research skill)"
+    for src_name, dest_name in _SKILL_FILES:
+        try:
+            content = (
+                importlib.resources.files("hyperresearch.skills")
+                .joinpath(src_name)
+                .read_text(encoding="utf-8")
+            )
+        except Exception:
+            # Fallback: read from source tree relative to this file
+            skill_src = Path(__file__).parent.parent / "skills" / src_name
+            if not skill_src.exists():
+                continue
+            content = skill_src.read_text(encoding="utf-8")
+
+        dest_path = skill_dir / dest_name
+        if dest_path.exists() and dest_path.read_text(encoding="utf-8") == content:
+            continue
+
+        dest_path.write_text(content, encoding="utf-8")
+        installed.append(dest_name)
+
+    pruned: list[str] = []
+    for existing in skill_dir.glob("SKILL*.md"):
+        if existing.name not in expected:
+            existing.unlink()
+            pruned.append(existing.name)
+
+    if not installed and not pruned:
+        return None
+
+    parts: list[str] = []
+    if installed:
+        parts.append(", ".join(installed))
+    if pruned:
+        parts.append("pruned: " + ", ".join(pruned))
+    return f"Claude Code: .claude/skills/hyperresearch/ ({'; '.join(parts)})"

--- a/src/hyperresearch/core/migrations.py
+++ b/src/hyperresearch/core/migrations.py
@@ -3,10 +3,28 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Callable
 
-# Each migration is a SQL script that upgrades from version N-1 to N.
+# Each migration upgrades from version N-1 to N. May be either:
+#   - a SQL string (executed via executescript)
+#   - a callable(conn) for migrations that need conditional logic (e.g. ADD COLUMN)
 # Migrations MUST be idempotent (safe to re-run).
-MIGRATIONS: dict[int, str] = {
+
+
+def _migrate_v6_tier_content_type(conn: sqlite3.Connection) -> None:
+    """Add tier and content_type columns to notes (idempotent)."""
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(notes)")}
+    if "tier" not in existing:
+        conn.execute("ALTER TABLE notes ADD COLUMN tier TEXT")
+    if "content_type" not in existing:
+        conn.execute("ALTER TABLE notes ADD COLUMN content_type TEXT")
+    conn.executescript("""
+        CREATE INDEX IF NOT EXISTS idx_notes_tier ON notes(tier);
+        CREATE INDEX IF NOT EXISTS idx_notes_content_type ON notes(content_type);
+    """)
+
+
+MIGRATIONS: dict[int, str | Callable[[sqlite3.Connection], None]] = {
     2: """
 CREATE TABLE IF NOT EXISTS tag_aliases (
     alias     TEXT PRIMARY KEY,
@@ -47,6 +65,7 @@ CREATE INDEX IF NOT EXISTS idx_assets_type ON assets(type);
 -- removed from code. Left as vestigial columns in existing DBs for compatibility.
 -- New vaults won't have them. No structural changes needed.
 """,
+    6: _migrate_v6_tier_content_type,
 }
 
 
@@ -66,9 +85,12 @@ def migrate(conn: sqlite3.Connection, target_version: int) -> list[int]:
 
     applied = []
     for version in range(current + 1, target_version + 1):
-        sql = MIGRATIONS.get(version)
-        if sql:
-            conn.executescript(sql)
+        migration = MIGRATIONS.get(version)
+        if migration:
+            if callable(migration):
+                migration(conn)
+            else:
+                conn.executescript(migration)
         conn.execute(
             "INSERT OR REPLACE INTO _meta (key, value) VALUES ('schema_version', ?)",
             (str(version),),

--- a/src/hyperresearch/core/note.py
+++ b/src/hyperresearch/core/note.py
@@ -8,7 +8,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from hyperresearch.core.frontmatter import parse_frontmatter, render_note
-from hyperresearch.core.patterns import CODE_BLOCK_RE, INLINE_CODE_RE, WIKI_LINK_RE
+from hyperresearch.core.patterns import (
+    CODE_BLOCK_RE,
+    INLINE_CODE_RE,
+    WIKI_LINK_RE,
+    is_valid_wiki_link_target,
+)
 from hyperresearch.models.note import Note, NoteMeta, slugify
 
 
@@ -25,14 +30,12 @@ def read_note(file_path: Path, vault_root: Path) -> Note:
     if not meta.id:
         meta.id = slugify(file_path.stem)
 
-    # Extract outgoing wiki links
+    # Extract outgoing wiki links, filtering citation footnotes and URLs
     cleaned = CODE_BLOCK_RE.sub("", body)
     cleaned = INLINE_CODE_RE.sub("", cleaned)
     raw_links = (m.group(1).strip().rstrip("\\") for m in WIKI_LINK_RE.finditer(cleaned))
     outgoing = list(dict.fromkeys(
-        ref for ref in raw_links
-        if ref and not ref.startswith(("http://", "https://", "ftp://", "mailto:"))
-        and not ref.isdigit()  # Skip [[100]]-style citation numbers
+        ref for ref in raw_links if is_valid_wiki_link_target(ref)
     ))
 
     # Word count (simple split)
@@ -60,12 +63,16 @@ def write_note(
     parent: str | None = None,
     source: str | None = None,
     summary: str | None = None,
+    tier: str | None = None,
+    content_type: str | None = None,
     extra_frontmatter: dict | None = None,
 ) -> Path:
     """Create a new note file on disk. Returns the file path.
 
     Args:
         notes_dir: The directory to write into (e.g. vault.notes_dir).
+        tier: Epistemic role — ground_truth|institutional|practitioner|commentary|unknown.
+        content_type: Artifact kind — paper|docs|article|blog|forum|dataset|policy|code|book|transcript|review|unknown.
         extra_frontmatter: Additional fields to set on NoteMeta (e.g. source_domain, fetched_at).
     """
     nid = note_id or slugify(title)
@@ -78,6 +85,8 @@ def write_note(
         parent=parent,
         source=source,
         summary=summary,
+        tier=tier,
+        content_type=content_type,
         created=datetime.now(UTC),
     )
     if extra_frontmatter:

--- a/src/hyperresearch/core/patterns.py
+++ b/src/hyperresearch/core/patterns.py
@@ -10,3 +10,84 @@ WIKI_LINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 # Code block patterns for stripping before link extraction
 CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
 INLINE_CODE_RE = re.compile(r"`[^`]+`")
+
+
+# Citation-footnote patterns that should NOT be treated as wiki-links even
+# though crawl4ai sometimes renders them as [[100]] or [[^100]] in fetched
+# markdown. These originate from Wikipedia-style footnote markup like
+# `[[100]](https://en.wikipedia.org/wiki/Foo#cite_note-100)` where the
+# visible text is the citation number in brackets.
+_CITATION_FOOTNOTE_RE = re.compile(
+    r"^\^?\d+(?:[\s,;\-]+\d+)*$"
+)
+
+# Explicit citation prefixes: [[cite-1]], [[ref_2]], [[fn:3]], [[note-4]]
+_CITE_PREFIX_RE = re.compile(
+    r"^(?:cite|ref|note|fn|footnote|endnote)[-_:]?\d+$",
+    re.IGNORECASE,
+)
+
+# Roman-numeral footnotes: [[iv]], [[xii]], [[ccxliv]] (lowercase or upper).
+# Academic papers use these for appendices and preface footnotes. Uses the
+# standard Roman-numeral grammar (not just "chars in [ivxlcdm]") so real
+# words like "civic" or "mix" don't match by accident. The empty string is
+# explicitly excluded — it would otherwise match M{0}X{0}I{0}.
+_ROMAN_FOOTNOTE_RE = re.compile(
+    r"^(?=[ivxlcdm])M{0,4}(?:CM|CD|D?C{0,3})(?:XC|XL|L?X{0,3})(?:IX|IV|V?I{0,3})$",
+    re.IGNORECASE,
+)
+
+# Symbol footnotes: [[*]], [[**]], [[†]], [[‡]], [[§]], [[¶]], [[#]], [[△]].
+# Typography-style footnote markers used in older academic publishing.
+_SYMBOL_FOOTNOTE_RE = re.compile(
+    r"^[\*\u2020\u2021\u00a7\u00b6#\u25b3\u25bd]{1,3}$"
+)
+
+# Figure / table / equation references: [[fig-3]], [[tab-1]], [[eq-2]],
+# [[table1]], [[figure-4b]], [[eq:7]], [[scheme-3]]. These are cross-
+# references within a document, not wiki-links to other notes.
+_DOC_REF_PREFIX_RE = re.compile(
+    r"^(?:fig(?:ure)?|tab(?:le)?|eq(?:uation)?|scheme|chart|plate|box|chart|algo(?:rithm)?)[-_:]?\w*$",
+    re.IGNORECASE,
+)
+
+
+def is_valid_wiki_link_target(ref: str) -> bool:
+    """Return True if a ``[[ref]]`` should be treated as a note reference.
+
+    Filters out content that crawl4ai and other markdown fetchers sometimes
+    produce as double-bracket targets but that should NOT resolve to notes:
+
+    - Empty / whitespace-only refs
+    - URLs (``http://``, ``https://``, ``ftp://``, ``mailto:``)
+    - Anchors (``#section-id``) and absolute paths (``/path/to/thing``)
+    - Pure-numeric citation footnotes: ``[[100]]``, ``[[^100]]``,
+      ``[[100,101]]``, ``[[1-5]]``, ``[[100; 101]]``
+    - Explicit citation prefixes: ``[[cite-1]]``, ``[[ref_2]]``, ``[[fn:3]]``,
+      ``[[note-4]]``, ``[[footnote-5]]``
+    - Roman-numeral footnotes: ``[[iv]]``, ``[[xii]]``
+    - Symbol footnotes: ``[[*]]``, ``[[**]]``, ``[[†]]``, ``[[‡]]``, ``[[§]]``
+    - Document cross-references: ``[[fig-3]]``, ``[[tab-1]]``, ``[[eq-2]]``,
+      ``[[figure-4b]]``, ``[[scheme-3]]``, ``[[algorithm-2]]``
+
+    Valid note references starting with digits (e.g. ``[[10-rules-for-X]]``)
+    are preserved because they contain non-digit characters.
+    """
+    if not ref:
+        return False
+    ref = ref.strip()
+    if not ref:
+        return False
+    if ref.startswith(("http://", "https://", "ftp://", "mailto:", "#", "/")):
+        return False
+    if _CITATION_FOOTNOTE_RE.match(ref):
+        return False
+    if _CITE_PREFIX_RE.match(ref):
+        return False
+    if _ROMAN_FOOTNOTE_RE.match(ref):
+        return False
+    if _SYMBOL_FOOTNOTE_RE.match(ref):
+        return False
+    if _DOC_REF_PREFIX_RE.match(ref):
+        return False
+    return True

--- a/src/hyperresearch/core/patterns.py
+++ b/src/hyperresearch/core/patterns.py
@@ -88,6 +88,4 @@ def is_valid_wiki_link_target(ref: str) -> bool:
         return False
     if _SYMBOL_FOOTNOTE_RE.match(ref):
         return False
-    if _DOC_REF_PREFIX_RE.match(ref):
-        return False
-    return True
+    return not _DOC_REF_PREFIX_RE.match(ref)

--- a/src/hyperresearch/core/sync.py
+++ b/src/hyperresearch/core/sync.py
@@ -10,7 +10,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from hyperresearch.core.note import read_note, strip_markdown
-from hyperresearch.core.patterns import CODE_BLOCK_RE, INLINE_CODE_RE, WIKI_LINK_RE
+from hyperresearch.core.patterns import (
+    CODE_BLOCK_RE,
+    INLINE_CODE_RE,
+    WIKI_LINK_RE,
+    is_valid_wiki_link_target,
+)
 
 
 @dataclass
@@ -42,13 +47,24 @@ def compute_sync_plan(vault, force: bool = False) -> SyncPlan:
     plan = SyncPlan()
 
     # Only scan inside the research directory (notes/, index/)
-    # This avoids walking .git/, .venv/, src/, etc. entirely
+    # This avoids walking .git/, .venv/, src/, etc. entirely.
+    #
+    # Files at the research/ root (e.g. research/scaffold.md,
+    # research/comparisons.md, research/synthesis.md) are STAGING files the
+    # agent writes then registers as real notes via `note new --body-file`.
+    # They must NOT be synced as notes themselves — otherwise every run
+    # produces 4 orphan notes and the missing-title/missing-tags/missing-summary
+    # lint rules spam warnings for every research session.
     kb_dir = vault.research_dir
     if not kb_dir.exists():
         return plan
 
     disk_files: dict[str, float] = {}
     for md_file in kb_dir.rglob("*.md"):
+        # Skip staging files at the research/ root. Real notes live in
+        # research/notes/** or research/index/**.
+        if md_file.parent == kb_dir:
+            continue
         rel = md_file.relative_to(vault.root).as_posix()
         disk_files[rel] = md_file.stat().st_mtime
 
@@ -155,13 +171,14 @@ def _upsert_note_to_db(conn, note, synced_at: str, file_mtime: float = 0) -> Non
     conn.execute(
         """
         INSERT INTO notes
-            (id, title, path, status, type, source, parent,
+            (id, title, path, status, type, tier, content_type, source, parent,
              deprecated, reviewed, expires, word_count, summary,
              created, updated, file_mtime, content_hash, synced_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             title=excluded.title, path=excluded.path, status=excluded.status,
-            type=excluded.type, source=excluded.source, parent=excluded.parent,
+            type=excluded.type, tier=excluded.tier, content_type=excluded.content_type,
+            source=excluded.source, parent=excluded.parent,
             deprecated=excluded.deprecated,
             reviewed=excluded.reviewed, expires=excluded.expires,
             word_count=excluded.word_count, summary=excluded.summary,
@@ -171,6 +188,7 @@ def _upsert_note_to_db(conn, note, synced_at: str, file_mtime: float = 0) -> Non
         """,
         (
             meta.id, meta.title, note.path, meta.status, meta.type,
+            meta.tier, meta.content_type,
             meta.source, meta.parent, 1 if meta.deprecated else 0,
             reviewed_iso, expires_iso,
             note.word_count, meta.summary, created_iso, updated_iso,
@@ -213,16 +231,14 @@ def _upsert_note_to_db(conn, note, synced_at: str, file_mtime: float = 0) -> Non
     )
 
     # Update links — extract from original body (not stripped)
+    # Uses the shared filter so this path stays in sync with core.note.read_note
     conn.execute("DELETE FROM links WHERE source_id = ?", (meta.id,))
     cleaned = CODE_BLOCK_RE.sub("", note.body)
     cleaned = INLINE_CODE_RE.sub("", cleaned)
     for line_num, line in enumerate(cleaned.split("\n"), 1):
         for m in WIKI_LINK_RE.finditer(line):
             target_ref = m.group(1).strip().rstrip("\\")  # Strip trailing backslash (shell escaping artifact)
-            # Skip URLs — they're not note references
-            if target_ref.startswith(("http://", "https://", "ftp://", "mailto:")):
-                continue
-            if not target_ref:
+            if not is_valid_wiki_link_target(target_ref):
                 continue
             conn.execute(
                 "INSERT OR IGNORE INTO links (source_id, target_ref, line_number, context) "

--- a/src/hyperresearch/core/vault.py
+++ b/src/hyperresearch/core/vault.py
@@ -38,6 +38,10 @@ class Vault:
     def db(self) -> sqlite3.Connection:
         if self._conn is None:
             self._conn = get_connection(self.db_path)
+            # Ensure schema is up to date — init_schema is idempotent and runs
+            # any pending migrations. This fires on every vault open, which is
+            # cheap when there's nothing to migrate.
+            init_schema(self._conn)
         return self._conn
 
     @property

--- a/src/hyperresearch/models/note.py
+++ b/src/hyperresearch/models/note.py
@@ -25,6 +25,31 @@ class NoteType(StrEnum):
     MOC = "moc"
 
 
+class Tier(StrEnum):
+    """Epistemic role of a source — how it functions as evidence."""
+    GROUND_TRUTH = "ground_truth"
+    INSTITUTIONAL = "institutional"
+    PRACTITIONER = "practitioner"
+    COMMENTARY = "commentary"
+    UNKNOWN = "unknown"
+
+
+class ContentType(StrEnum):
+    """Artifact kind — what the note physically is."""
+    PAPER = "paper"
+    DOCS = "docs"
+    ARTICLE = "article"
+    BLOG = "blog"
+    FORUM = "forum"
+    DATASET = "dataset"
+    POLICY = "policy"
+    CODE = "code"
+    BOOK = "book"
+    TRANSCRIPT = "transcript"
+    REVIEW = "review"
+    UNKNOWN = "unknown"
+
+
 def slugify(text: str) -> str:
     """Convert text to a URL-friendly slug. Preserves underscores."""
     text = text.lower().strip()
@@ -56,12 +81,15 @@ class NoteMeta(BaseModel):
     fetch_provider: str | None = None
     status: NoteStatus = NoteStatus.DRAFT
     type: NoteType = NoteType.NOTE
+    tier: Tier | None = None             # Epistemic role (ground_truth/institutional/practitioner/commentary)
+    content_type: ContentType | None = None  # Artifact kind (paper/docs/article/blog/...)
     aliases: list[str] = Field(default_factory=list)
     parent: str | None = None
     deprecated: bool = False             # Explicitly marked as outdated
     reviewed: datetime | None = None     # Last time a human verified accuracy
     expires: datetime | None = None      # Auto-stale after this date
     summary: str | None = None
+    raw_file: str | None = None          # Relative path to raw artifact (e.g. raw/<id>.pdf)
 
     @field_validator("tags", mode="before")
     @classmethod

--- a/src/hyperresearch/search/filters.py
+++ b/src/hyperresearch/search/filters.py
@@ -10,6 +10,8 @@ class SearchFilters:
     tags: list[str] | None = None
     status: str | None = None
     note_type: str | None = None
+    tier: str | None = None           # Epistemic tier filter
+    content_type: str | None = None   # Artifact kind filter
     after: str | None = None
     before: str | None = None
     path_glob: str | None = None
@@ -41,6 +43,14 @@ class SearchFilters:
         if self.note_type:
             clauses.append(f"{table_alias}.type = ?")
             params.append(self.note_type)
+
+        if self.tier:
+            clauses.append(f"{table_alias}.tier = ?")
+            params.append(self.tier)
+
+        if self.content_type:
+            clauses.append(f"{table_alias}.content_type = ?")
+            params.append(self.content_type)
 
         if self.after:
             clauses.append(f"{table_alias}.created >= ?")

--- a/src/hyperresearch/search/fts.py
+++ b/src/hyperresearch/search/fts.py
@@ -113,8 +113,9 @@ def search_fts(
             "path": row["path"],
             "status": row["status"],
             "type": row["type"],
-            "tier": row["tier"] if "tier" in row else None,  # noqa: SIM401 (sqlite3.Row has no .get())
-            "content_type": row["content_type"] if "content_type" in row else None,  # noqa: SIM401
+            # sqlite3.Row.__contains__ is broken; row.keys() is reliable.
+            "tier": row["tier"] if "tier" in row.keys() else None,  # noqa: SIM118
+            "content_type": row["content_type"] if "content_type" in row.keys() else None,  # noqa: SIM118
             "tags": tag_list,
             "created": row["created"],
             "updated": row["updated"],

--- a/src/hyperresearch/search/fts.py
+++ b/src/hyperresearch/search/fts.py
@@ -113,8 +113,8 @@ def search_fts(
             "path": row["path"],
             "status": row["status"],
             "type": row["type"],
-            "tier": row["tier"] if "tier" in row.keys() else None,
-            "content_type": row["content_type"] if "content_type" in row.keys() else None,
+            "tier": row["tier"] if "tier" in row else None,  # noqa: SIM401 (sqlite3.Row has no .get())
+            "content_type": row["content_type"] if "content_type" in row else None,  # noqa: SIM401
             "tags": tag_list,
             "created": row["created"],
             "updated": row["updated"],

--- a/src/hyperresearch/search/fts.py
+++ b/src/hyperresearch/search/fts.py
@@ -83,7 +83,7 @@ def search_fts(
 
     sql = f"""
         SELECT
-            n.id, n.title, n.path, n.status, n.type,
+            n.id, n.title, n.path, n.status, n.type, n.tier, n.content_type,
             n.created, n.updated, n.word_count, n.summary,
             snippet(notes_fts, 2, '>>>', '<<<', '...', 64) as snippet,
             bm25(notes_fts, 0.0, {tw}, {bw}, {tgw}, {aw}) as score,
@@ -113,6 +113,8 @@ def search_fts(
             "path": row["path"],
             "status": row["status"],
             "type": row["type"],
+            "tier": row["tier"] if "tier" in row.keys() else None,
+            "content_type": row["content_type"] if "content_type" in row.keys() else None,
             "tags": tag_list,
             "created": row["created"],
             "updated": row["updated"],

--- a/src/hyperresearch/skills/research-collect.md
+++ b/src/hyperresearch/skills/research-collect.md
@@ -1,0 +1,127 @@
+---
+name: research-collect
+description: >
+  Enumerative coverage research. The user wants to know what exists, what
+  happened, who did what — in full. Primary virtue is exhaustive per-entity
+  coverage with every requested field. Sources are artifacts, official
+  references, and anything that establishes ground truth on what's in the set.
+---
+
+# Collect Protocol
+
+> You are in **collect** modality. The dispatcher routed you here because the output needs to enumerate a set of entities or facts, not advance a thesis. If the prompt said "for each X, provide Y / Z / W", the contract is clear: every X gets every field. If the prompt named a category without naming members, your job is to identify the significant members and cover them.
+
+Read the dispatcher (`.claude/skills/hyperresearch/SKILL.md`) for the process. This file is the SUBSTANCE reference for collect.
+
+---
+
+## What collect is for
+
+| Prompt shape | Why it's collect |
+|---|---|
+| "For each Napoleonic marshal, cover key campaigns, defeat, and death" | Per-entity field list |
+| "Analyze the armor classes in Saint Seiya: for each significant character, provide power / technique / arc / fate" | Per-entity field list |
+| "List the major infrastructure bills passed between 2020 and 2025 with their key provisions" | Enumerative scope |
+| "What are all the endogenous opioid receptors and what does each do?" | Enumerative scope |
+| "Survey the state capitals of India and their major industries" | Per-entity field list |
+
+Collect is NOT for: "explain how X works" (synthesize), "which is best, X or Y" (compare), "will X happen in 2026" (forecast).
+
+---
+
+## Source strategy
+
+Collect is **primary-source-heavy for the artifact itself, then secondary for the per-entity fields.**
+
+**Ground truth (first priority):**
+- Official / authoritative registries, directories, catalogs, databases — whatever lists the enumerable set
+- The primary artifact itself (if the subject is a text, franchise, or body of work)
+- For historical enumerations: primary documents, archival sources, official records
+- For scientific enumerations: peer-reviewed classifications, reference databases (NCBI, ChEBI, PDB, etc.)
+
+**Institutional signal (second priority):**
+- Encyclopedia entries (Wikipedia, domain-specific wikis — these are load-bearing for collect because they often *are* the enumerable set)
+- Reference books and field handbooks
+- Academic reviews that enumerate and classify
+
+**Practitioner triangulation (third priority):**
+- Named practitioners who have catalogued the set (niche experts, fandom compilers, historical societies)
+- Community-curated databases (TV Tropes, Fandom wikis, GitHub awesome-lists)
+
+**Commentary (de-prioritized):**
+- Listicles and "top N" posts are often derivative of the reference sources above. Use them only as leads, not as citations for per-entity facts.
+
+### Academic sweep — only if peer-reviewed literature enumerates the set
+
+Run Semantic Scholar / OpenAlex only if the enumerable set has a scholarly classification literature. For fictional / pop-culture / product / historical enumerations, skip it — the reference wikis and primary sources are the authoritative tier.
+
+### Adversarial round
+
+Still required. Run the dispatcher's adversarial searches to catch:
+- Missing members the consensus list omits
+- Disputed members (is this really in the set?)
+- Members that get grouped differently in non-mainstream sources
+
+A collect report with no engagement with classification disputes is a transcription, not research.
+
+---
+
+## Substance rules for Step 9 (writing)
+
+These are the collect-specific rules that layer on top of the dispatcher's shared writing constraints.
+
+### 1. The coverage contract is non-negotiable
+
+If the prompt says "for each X, provide Y / Z / W", the draft must deliver every X with every field. If the prompt named 108 entities, the draft covers all 108. If the prompt said "each significant X", YOU define the significance threshold explicitly in the scaffold (e.g., "named in ≥2 primary sources" or "featured in a canonical arc"), state it in the opening, and then honor it without silent downgrades.
+
+**Representative examples + thematic commentary is NOT a substitute for enumerative coverage.** If you cannot deliver the full set inside the draft, surface that to the user and ask — do not paper over it.
+
+### 2. Proportionate depth across entities
+
+Every entity the prompt asked about gets proportionate treatment. If Gold Saint #1 gets 200 words, Gold Saint #12 gets approximately 200 words. Deeply over-covering the famous entries and thin-covering the obscure ones is a violation — the prompt asked for "each", not "the ones you find interesting".
+
+### 3. Structured entity treatment is allowed and expected
+
+Collect is the one activity where **structured per-entity treatment** (including tight dossier-style subsections, roundup tables, or densely packed per-entity paragraphs) is the correct shape. You do NOT have to write full essayistic paragraphs for every entity. A per-entity subsection with clear field labels (technique, role, fate, outcome) and 2–4 sentences of prose per field is correct, efficient, and legible.
+
+However: **dense roundup is not license for bullet-only listicles.** Each field still needs a sentence of context or consequence, not just a 3-word noun phrase. And the section as a whole still needs an opening orientation paragraph and a closing analytical beat — the per-entity dossier is flanked by interpretive framing, not presented raw.
+
+### 4. Grouping is legitimate when the set is very large
+
+For sets larger than you can cover with individual treatment (100+ entities), group by natural categorical structure (rank, era, region, function). Every entity still appears, but less-significant entities can share a subsection with shorter per-entity lines. The scaffold's coverage checklist records the grouping strategy; the auditor verifies every entity from the source set is accounted for.
+
+### 5. Opening establishes the scope and the significance threshold
+
+The opening answers: *what is the set you're enumerating, how did you define its boundaries, and what significance threshold did you apply*. A reader must understand in the first 200 words what "every X" means in this draft. If the set has disputed membership, the opening names the dispute and states your inclusion rule.
+
+### 6. Closing synthesizes the set
+
+The closing section (before the Opinionated Synthesis) draws out what the enumeration as a whole reveals. This is where a collect draft earns its analytical beat: what pattern does the full set expose? What does the coverage reveal that no single entity could? This is NOT a thesis replacement — the draft is primarily enumerative — but every corpus-level report should have one moment where the whole is more than the sum.
+
+---
+
+## Conformance checks (auditor reads this at Step 11, mode=conformance)
+
+When the auditor runs in conformance mode on a collect draft, it applies these checks in order. Each is a PASS / FAIL with a one-line quote from the report or the vault.
+
+(0) **Verbatim prompt check.** Open `research/scaffold.md` — does its first section contain the user's verbatim prompt (unchanged, not paraphrased)? FAIL if missing or modified.
+
+(1) **Coverage contract check.** Read the scaffold's "What the user explicitly asked for" section. For each explicit entity or field requirement, verify the draft delivers it. If the user said "for each of 108 Specters provide techniques and fate", count the draft's Specter entries and verify every entry has both fields. FAIL if any entity or field is silently dropped.
+
+(2) **Proportionate depth check.** Count substantive claims per entity across the draft (not raw word count — count assertions about the entity's attributes, actions, or fate). Flag any entity with less than ~50% the depth of the most-covered entity in the same category. FAIL if the draft over-develops the famous entries and thins the obscure ones.
+
+(3) **Scaffold + comparisons + extract artifacts exist.** Run `$HPR search 'scaffold' -j`, `$HPR search 'comparisons' -j`, and `$HPR note list --tag extract -j`. All must return non-empty. FAIL otherwise.
+
+(4) **Provenance chain.** Run `$HPR lint --rule provenance -j`. FAIL if any `--suggested-by` issues.
+
+(5) **Analyst coverage.** Run `$HPR lint --rule analyst-coverage -j`. FAIL if the extract:source ratio is below 30%.
+
+(6) **Opening scope + significance threshold.** Read the opening. Does it state what set is being enumerated, how boundaries were defined, and what significance threshold was applied? FAIL if any of the three is missing.
+
+(7) **Corpus-level analytical beat.** Read the closing body section (not the Opinionated Synthesis). Does it draw out a pattern the full set reveals? FAIL if the closing is just a transition to synthesis without a substantive pattern claim.
+
+(8) **Adversarial engagement.** Does the draft acknowledge at least one disputed / ambiguous / contested classification? FAIL if the enumeration is presented as uncontested when the adversarial search round found disputes.
+
+(9) **Cross-source tension at least twice.** At least two body sections must put specific sources in tension with explicit "Source A says X; Source B says Y; I hold Z because..." structure. FAIL if the draft only cites, never contrasts.
+
+Auditor output: list every violation with a one-line quote from the report. The parent agent applies fixes.

--- a/src/hyperresearch/skills/research-collect.md
+++ b/src/hyperresearch/skills/research-collect.md
@@ -55,14 +55,19 @@ Collect is **primary-source-heavy for the artifact itself, then secondary for th
 
 Run Semantic Scholar / OpenAlex only if the enumerable set has a scholarly classification literature. For fictional / pop-culture / product / historical enumerations, skip it — the reference wikis and primary sources are the authoritative tier.
 
-### Adversarial round
+### Adversarial round — MANDATORY, run all three before proceeding
 
-Still required. Run the dispatcher's adversarial searches to catch:
-- Missing members the consensus list omits
-- Disputed members (is this really in the set?)
-- Members that get grouped differently in non-mainstream sources
+A collect report with no engagement with classification disputes is a transcription, not research. Run all three searches and **fetch at least one source that explicitly disputes the consensus list / classification**:
 
-A collect report with no engagement with classification disputes is a transcription, not research.
+```
+WebSearch("<topic> disputed contested membership classification")
+WebSearch("missing from <consensus list> <topic> overlooked")
+WebSearch("<topic> alternative classification non-mainstream taxonomy")
+```
+
+If the set has a "minor" / "non-canonical" / "rejected" / "lost" / "obscure" tier (e.g., apocryphal works, deprecated species, withdrawn standards), search for it explicitly and fetch one such source. The audit at Step 11 verifies at least one source flagged a missing or disputed member — a corpus that only contains consensus-list confirmations fails the comprehensiveness check.
+
+Specific dispute patterns to watch for: members the consensus list omits, members whose membership is contested, members that get grouped differently in non-mainstream sources, ordering / hierarchy disputes within the set.
 
 ---
 

--- a/src/hyperresearch/skills/research-compare.md
+++ b/src/hyperresearch/skills/research-compare.md
@@ -75,9 +75,9 @@ Compare is a **3-tier source hierarchy** that privileges the artifact itself, th
 
 Never use commentary as the sole source for a factual claim about an entity. Use it only to characterize positioning or reception.
 
-### Adversarial round
+### Adversarial round — MANDATORY, run all four before proceeding
 
-Required — specifically for the market leader. A compare report without at least one source critical of the dominant entity is advocacy, not evaluation.
+Required — specifically for the market leader. A compare report without at least one source critical of the dominant entity is advocacy, not evaluation. **Fetch at least one source that explicitly criticizes the leading entity** (a postmortem, a "why we migrated away" blog, a dissenting analyst report, a public outage retrospective, a regulatory complaint).
 
 ```
 WebSearch("<market-leader entity> problems limitations")
@@ -85,6 +85,10 @@ WebSearch("<market-leader entity> alternatives why leave")
 WebSearch("moving away from <market-leader entity>")
 WebSearch("<method A> vs <method B> when <method A> wins")
 ```
+
+The audit at Step 11 verifies at least one body section engages the critique with substance. A compare draft that recommends X without engaging "people who tried X and switched to Y" lacks the experiential evidence that distinguishes a real evaluation from a marketing summary.
+
+For symmetric comparisons (no clear leader, e.g., "Postgres vs MySQL"), run the adversarial searches against EACH entity — every option must have at least one critical voice in the corpus.
 
 ### Academic sweep — only when comparing methods, not products
 

--- a/src/hyperresearch/skills/research-compare.md
+++ b/src/hyperresearch/skills/research-compare.md
@@ -1,0 +1,169 @@
+---
+name: research-compare
+description: >
+  Comparative evaluation research. The user wants to know which option is
+  better for what, how alternatives differ, and which one to pick. Primary
+  virtue is proportionate per-entity depth plus a committed recommendation.
+  Covers vendor scans, tool evaluations, approach selection, and any
+  prompt that names multiple alternatives.
+---
+
+# Compare Protocol
+
+> You are in **compare** modality. The dispatcher routed you here because the output needs to evaluate N alternatives against each other and commit to a recommendation. The reader leaves knowing which option to pick and why, plus the conditions under which alternatives win.
+
+Read the dispatcher (`.claude/skills/hyperresearch/SKILL.md`) for the process. This file is the SUBSTANCE reference for compare.
+
+---
+
+## What compare is for
+
+| Prompt shape | Why it's compare |
+|---|---|
+| "TigerBeetle vs Postgres vs FoundationDB for write-heavy workloads" | Named alternatives, explicit comparison |
+| "Which JavaScript framework should I pick for a new SaaS startup" | Unnamed set, evaluation ask |
+| "How does Kubernetes compare to Nomad for stateful workloads" | Two named alternatives |
+| "What's the best reinforcement learning approach for robotic manipulation" | Named alternatives, selection ask |
+| "Compare TLS 1.3 with QUIC for mobile apps" | Two named alternatives, comparison ask |
+
+Compare is NOT for: "what exists" (collect), "explain how X works" (synthesize), "will X win" (forecast — if the ask is future-tense).
+
+**Two variants:**
+1. **market-scan** — entity set is discovered through research (the user asked about a space, not specific alternatives)
+2. **comparison** — entity set is named explicitly in the prompt
+
+Both use this file. The variants differ only in how you acquire the entity list.
+
+---
+
+## Source strategy
+
+Compare is a **3-tier source hierarchy** that privileges the artifact itself, then authoritative synthesis, then practitioner reality checks.
+
+### Ground truth (first priority — fetch for every entity)
+
+- Official product / project pages, feature lists, pricing pages, API documentation, release notes
+- Company filings, official announcements, specs
+- Benchmark results (both official and independent)
+- Source code / README / architecture docs for open-source entities
+- Standards documents (RFC, ISO, IEEE) when the entities implement a standard
+
+**For comparison variant:** fetch ground-truth sources for EACH named entity before moving to Tier 2. Imbalanced ground-truth coverage (entity A has 5 primary sources, entity B has 1) propagates to imbalanced body sections later.
+
+### Institutional signal (second priority)
+
+- Authoritative analyst reports and research firm writing
+- Named expert reviews and long-form evaluations by recognized practitioners
+- Academic / technical papers when the comparison is between methods rather than products
+- Industry benchmarking bodies and standards organizations
+
+**Paywall fallback:** when reports are gated: (1) search for "[report title] key findings"; (2) look for press coverage of the report; (3) find earlier free editions; (4) check the organization's free-publications section.
+
+### Practitioner triangulation (third priority)
+
+- Named practitioner postmortems and migration reports (the most honest signal in the ecosystem)
+- Conference talks with transcripts (by practitioners who built the thing, not evangelists)
+- StackOverflow canonical answers (accepted + high-upvote)
+- Community threads (Hacker News, Reddit, Lobste.rs) on specific failure modes
+- User reviews on professional review sites (not single-line "it's great" reviews)
+
+### Commentary (load-bearing only for reception, not facts)
+
+- News articles about product launches
+- Blog summaries by authors who haven't used the thing
+- Listicles
+
+Never use commentary as the sole source for a factual claim about an entity. Use it only to characterize positioning or reception.
+
+### Adversarial round
+
+Required — specifically for the market leader. A compare report without at least one source critical of the dominant entity is advocacy, not evaluation.
+
+```
+WebSearch("<market-leader entity> problems limitations")
+WebSearch("<market-leader entity> alternatives why leave")
+WebSearch("moving away from <market-leader entity>")
+WebSearch("<method A> vs <method B> when <method A> wins")
+```
+
+### Academic sweep — only when comparing methods, not products
+
+If the comparison is between academic methods, algorithms, or theoretical approaches (e.g., "PPO vs SAC for continuous control"), run Semantic Scholar first. If the comparison is between products or services, skip the academic sweep and go straight to vendor docs + analyst reports.
+
+---
+
+## Substance rules for Step 9 (writing)
+
+These are the compare-specific rules that layer on top of the dispatcher's shared writing constraints.
+
+### 1. Scoring dimensions declared upfront
+
+The opening establishes WHICH dimensions the entities will be evaluated on — and WHY those dimensions matter for the user's question. "Throughput", "correctness guarantees", "operational complexity", "ecosystem maturity" are dimensions; "performance" alone is not. Dimensions should reflect where the entities actually differ, not generic attributes.
+
+A compare draft with undeclared or arbitrary dimensions is a set of entity descriptions pretending to be an evaluation. Declare them first; score against them throughout.
+
+### 2. Proportionate depth per entity is the PRIMARY substance rule
+
+Every entity named in the prompt (or discovered during market-scan) gets proportionate body coverage. If entity A has a 1,200-word section and entity B has a 400-word section, rebalance — either expand B's coverage or trim A's.
+
+**This rule holds regardless of section structure.** Whether the draft has per-entity sections, per-dimension sections, clustered sections, or prose-embedded comparisons, count substantive claims per entity across the whole body. If one entity ends up with half the coverage of another, the research was lopsided, not the draft.
+
+### 3. A mandatory comparison matrix
+
+Somewhere in the body there is a table (or equivalent structured view) that places every entity against every scoring dimension. This is non-negotiable — no compare draft is complete without it. If the prompt requests prose comparison over a table, the matrix can be rendered as a structured prose section ("On throughput: A leads with X; B follows at Y; C lags at Z because..."), but every entity must be parseable on every dimension in a single view.
+
+If a dimension cannot be scored for an entity (e.g., a private company with no public pricing), note the gap and explain why. Do not silently omit cells.
+
+### 4. A committed recommendation
+
+Compare drafts MUST end with a committed pick: "For [primary use case], use X because [reason]. For [condition A], Y wins because [reason]. For [condition B], Z wins because [reason]." "It depends" alone is not acceptable — it must be followed by the conditions that determine the answer.
+
+The recommendation is a claim the reader can act on, not a balanced list.
+
+### 5. Entities in tension, not in isolation
+
+Body sections must put entities in direct tension: "A and B both claim to handle C; the difference is that A does C1 well while B does C2 well." A draft that describes each entity in isolation and then synthesizes at the end is missing the comparative substance that justifies the modality.
+
+### 6. Opening establishes the question the evaluation answers
+
+What is the user trying to decide? The draft frames this explicitly in the opening, then every body section is a step toward that decision. The opening is NOT a description of the first entity — it is the problem statement + the dimensions the solution will be scored on.
+
+### 7. Entity sections open with mechanism, then method
+
+For each entity: first explain what it IS and HOW it works (mechanism), then what you DO with it (method / usage / interface). Readers evaluate alternatives best when they understand the underlying model, not just the surface API.
+
+### 8. Honest about maturity asymmetry
+
+If the entities have dramatically different maturity (A has 10 years of production use and benchmarks; B is a 2024 research prototype with no independent replication), flag this explicitly in the opening AND in each affected section. Treating asymmetric alternatives as if they were evenly characterized is a form of dishonesty — the reader needs to know the evidence bases are uneven.
+
+---
+
+## Conformance checks (auditor reads this at Step 11, mode=conformance)
+
+(0) **Verbatim prompt check.** Open `research/scaffold.md` — does its first section contain the user's verbatim prompt (unchanged)? FAIL if missing or modified.
+
+(1) **All prompt-named entities appear.** If the prompt named specific entities, every one must appear in the draft with substantive coverage. FAIL if any named entity is missing or relegated to a passing mention.
+
+(2) **Scoring dimensions declared.** Read the opening. Are the comparison dimensions named and their relevance explained? FAIL if dimensions are undeclared or arbitrary.
+
+(3) **Proportionate depth per entity.** Count substantive claims per entity across the whole body. Flag any entity with less than ~50% the depth of the most-covered entity. FAIL if the draft over-develops one entity and thin-covers others.
+
+(4) **Comparison matrix present.** Find the matrix (table or structured prose). Verify every entity is scored on every declared dimension. FAIL if the matrix is missing, incomplete, or present only as a synthesis afterthought.
+
+(5) **Committed recommendation.** Read the recommendation section. Does it commit to a specific pick for the primary use case? If it uses "it depends", does it immediately enumerate the conditions and their answers? FAIL if the draft hedges without committing.
+
+(6) **Entities in tension.** Count body sections where entities are put in direct tension (not described in isolation). FAIL if fewer than two — isolation descriptions are not comparisons.
+
+(7) **Adversarial engagement with the market leader.** Find sources critical of the dominant entity. Is the draft's body engaging with those critiques, or is the recommendation a consensus echo? FAIL if there is zero engagement with dissent on the leader.
+
+(8) **Scaffold + comparisons + extract artifacts exist.** Run `$HPR search 'scaffold' -j`, `$HPR search 'comparisons' -j`, `$HPR note list --tag extract -j`. All non-empty. FAIL otherwise.
+
+(9) **Provenance chain.** Run `$HPR lint --rule provenance -j`. FAIL if any issues.
+
+(10) **Analyst coverage.** Run `$HPR lint --rule analyst-coverage -j`. FAIL if below 30%.
+
+(11) **Mechanism-before-method per entity.** Sample 3 entity sections. Does each open with mechanism (what it is, how it works) before method (how to use it)? FAIL if sections jump straight to usage without the underlying model.
+
+(12) **Maturity asymmetry flagged if present.** If the entities have dramatically different evidence bases, is this flagged in the opening and in affected sections? FAIL if the draft presents asymmetric alternatives as if they were evenly characterized.
+
+Auditor output: list every violation with a one-line quote from the report.

--- a/src/hyperresearch/skills/research-forecast.md
+++ b/src/hyperresearch/skills/research-forecast.md
@@ -63,9 +63,9 @@ Forecast is **secondary-heavy** — triangulation across many institutional pers
 
 Academic papers are the wrong sources for forecasting. Citation-ranked scholarship describes what's known about the past, not what will happen. Skip Semantic Scholar / arXiv / OpenAlex / PubMed for forecast queries.
 
-### Adversarial round — mandatory
+### Adversarial round — MANDATORY, run all five before proceeding
 
-Run these before proceeding past the seed fetch:
+A forecast without explicit engagement with the failure case is not analysis — it is advocacy. Run all five searches and **fetch at least one source that explicitly argues the bear case** (a contrarian analyst report, a named-skeptic op-ed, a historical-failure post-mortem):
 
 ```
 WebSearch("<topic> bear case downside risk")
@@ -75,7 +75,9 @@ WebSearch("<topic> worst case scenario")
 WebSearch("<topic> historical failure analogous case")
 ```
 
-A forecast without explicit engagement with the failure case is not analysis — it is advocacy.
+The audit at Step 11 verifies the bear case gets substantive coverage — at minimum a full paragraph engaging the contrarian position at its strongest, ideally a full section. A one-paragraph dismissal is strawmanning, not stress-testing.
+
+If the dominant forecast has a named skeptic (e.g., "consensus says soft landing but Roubini predicts X"), search for the skeptic by name. Named-contrarian search produces sharper dissent than generic "criticism of X".
 
 ---
 

--- a/src/hyperresearch/skills/research-forecast.md
+++ b/src/hyperresearch/skills/research-forecast.md
@@ -1,0 +1,163 @@
+---
+name: research-forecast
+description: >
+  Forward-looking research. The user wants to know what will happen or
+  what should be done. Primary virtue is a committed prediction or
+  recommendation grounded in past + current state with an explicit time
+  horizon. Sources are ground-truth statistics, institutional analysis,
+  policy documents, and practitioner positioning. NOT academic papers.
+---
+
+# Forecast Protocol
+
+> You are in **forecast** modality. The dispatcher routed you here because the output needs a committed position on something that has not yet happened: a prediction, a recommendation, a strategy. The reader leaves knowing what you expect / recommend and the reasoning chain that got you there. **Do not hedge.** Use probability language, not "it is possible".
+
+Read the dispatcher (`.claude/skills/hyperresearch/SKILL.md`) for the process. This file is the SUBSTANCE reference for forecast.
+
+---
+
+## What forecast is for
+
+| Prompt shape | Why it's forecast |
+|---|---|
+| "Will US inflation stay above 3% through 2026" | Prediction |
+| "What should the US Navy do about the China shipbuilding gap" | Strategy / recommendation |
+| "How will LLM pricing evolve over the next 2 years" | Forward-looking |
+| "Is the AI bubble going to burst and when" | Prediction |
+| "What's the right architecture for building a trading firm in 2026" | Forward-looking recommendation |
+
+Forecast is NOT for: "what exists now" (collect), "how does X work" (synthesize), "which option is best today" (compare).
+
+---
+
+## Source strategy
+
+Forecast is **secondary-heavy** — triangulation across many institutional perspectives matters more than any single primary source. BUT the forecast must still be **anchored in ground-truth** (official stats, filings, policy text). The structure is:
+
+**Ground truth (anchoring evidence):**
+- Official policy documents, regulatory filings, legislative text
+- Government statistics and economic data (central banks, national statistics offices, international bodies)
+- Company earnings guidance, SEC filings, official roadmaps and announcements
+- Primary datasets with time-series data for trend establishment
+
+**Time-horizon rule:** for 6–12 month forecasts, prioritize data from the last 12 months. For 3–5 year forecasts, prioritize structural trend data spanning 5–20 years. A short-horizon forecast built on 20-year structural data will miss the current regime; a long-horizon forecast built only on last-quarter data is noise-chasing.
+
+**Institutional signal (main triangulation layer):**
+- Research organizations and think-tanks relevant to your domain
+- Industry analysts and sector research firms
+- International organizations (IMF, OECD, World Bank for macro; ITU for telecom; IEA for energy)
+- Named economists, strategists, and domain experts in institutional roles
+
+**Find the right institutional voice for the domain.** Do not default to generic management consultants — find the analyst body with domain authority. Energy forecasts come from the IEA and industry-specific firms, not from McKinsey. Tech forecasts come from Gartner / IDC / 451 Research and specialized analysts, not general news.
+
+**Paywall fallback:** when reports are gated: (1) search for "[report title] key findings"; (2) press coverage of the report; (3) the organization's free-publications section; (4) earlier free editions.
+
+**Practitioner triangulation:**
+- Expert commentary — op-eds and essays by named practitioners (not anonymous)
+- Practitioner forecasts and positioning signals (how people operating in this domain are actually betting)
+- Conference keynotes with transcripts
+
+**Contrarian and dissenting voices:** independent analysts who challenge the consensus. These are load-bearing for forecast — the contrarian case is not optional; it must be represented with substance.
+
+### Do NOT run academic API sweeps
+
+Academic papers are the wrong sources for forecasting. Citation-ranked scholarship describes what's known about the past, not what will happen. Skip Semantic Scholar / arXiv / OpenAlex / PubMed for forecast queries.
+
+### Adversarial round — mandatory
+
+Run these before proceeding past the seed fetch:
+
+```
+WebSearch("<topic> bear case downside risk")
+WebSearch("<topic> contrarian view dissenting forecast")
+WebSearch("why <dominant forecast> is wrong")
+WebSearch("<topic> worst case scenario")
+WebSearch("<topic> historical failure analogous case")
+```
+
+A forecast without explicit engagement with the failure case is not analysis — it is advocacy.
+
+---
+
+## Substance rules for Step 9 (writing)
+
+These are the forecast-specific rules that layer on top of the dispatcher's shared writing constraints.
+
+### 1. Commit to a position
+
+The draft is built around a committed forecast or recommendation. Use probability language: "more likely than not", "substantial probability", "unlikely unless", "approaches certainty in the 12-month horizon". Do NOT use hedge language: "it is possible", "some experts believe", "time will tell". Probability language commits to a distribution; hedging commits to nothing.
+
+### 2. Time horizon is explicit
+
+Every forecast claim carries a time scope. If the user specified a horizon ("what happens by 2026"), deliver claims scoped to that horizon. If the prompt is silent on time, distinguish between:
+- **Short-term** (6–12 months): near-certain / high-confidence dynamics
+- **Medium-term** (1–3 years): trend-dependent, structural moves
+- **Long-term** (3–5+ years): speculative, path-dependent
+
+A forecast that conflates short- and long-term claims is incoherent. Either scope every claim or dedicate sections to each horizon.
+
+### 3. Directional commitment in the body, not only synthesis
+
+At least one substantive body section must take a clear directional stance — a claim about what will happen or what should be done. "The synthesis will take a position" is not sufficient. The reasoning has to commit along the way, not just at the end.
+
+If the user requested scenario-neutral analysis (e.g., "outline optimistic, central, and bear cases"), directional commitment lives *within each scenario branch*. Each scenario has a named probability and its own committed path — the branching is not an escape from commitment.
+
+### 4. Engage the contrarian case with substance
+
+Find the strongest argument against your forecast / recommendation. Give it real engagement — at minimum a full paragraph, ideally a full section. Represent it at its strongest. Then explain why you reject it.
+
+If the consensus view gets 3 sections of analysis, the bear case deserves comparable substantive coverage. A one-paragraph dismissal of dissent is strawmanning, not stress-testing.
+
+### 5. Historical precedent grounds the prediction
+
+Anchor forward-looking claims in at least one analogous historical case. "This looks like 1998-99 in tech valuations" is stronger than "valuations are high". If the domain is genuinely unprecedented (which is rare), say so explicitly and explain why past cases don't apply.
+
+A forecast with zero historical grounding has no epistemic floor — it is a guess.
+
+### 6. Tier weighting
+
+Anchor the forecast in `ground_truth` sources (official statistics, filings, policy text). Use `institutional` (analyst reports, think-tanks) for consensus positioning. Use `practitioner` (expert commentary, positioning signals) and `commentary` (contrarian op-eds) for the bear case and dissent.
+
+Do NOT build a forecast on `commentary` alone. A forecast grounded in news opinions is an opinion amplifier, not a forecast.
+
+### 7. Opening frames the decision and the forces
+
+The opening answers: *what decision or question is this answering, and what are the 3–5 forces that will determine the outcome*. The reader understands in the first 300 words what is at stake and what the draft is actually measuring.
+
+### 8. Explicit "what would change my mind"
+
+The draft must include — in the body or in the synthesis — a statement of what evidence would shift your position. "My forecast of X would flip if Y happens, because Z" is load-bearing: it separates a real forecast from a religious conviction.
+
+---
+
+## Conformance checks (auditor reads this at Step 11, mode=conformance)
+
+(0) **Verbatim prompt check.** Open `research/scaffold.md` — does its first section contain the user's verbatim prompt (unchanged)? FAIL if missing or modified.
+
+(1) **Committed position stated.** Read the opening and the synthesis. Is there a clear committed forecast / recommendation? FAIL if the draft hedges without committing or hides commitment behind "it depends" language alone.
+
+(2) **Probability language, not hedge language.** Sample 10 predictive claims in the body. Do they use probability language ("more likely than not", "substantial probability", "unlikely unless") or hedge language ("it is possible", "some experts believe")? FAIL if hedge language dominates.
+
+(3) **Time horizon explicit.** Every forecast claim carries a time scope — either inline or via sectioning (short-term / medium-term / long-term). FAIL if horizon is ambiguous or claims conflate time scales.
+
+(4) **Directional commitment in the body, not only synthesis.** At least one substantive body section takes a clear directional stance, not just the Opinionated Synthesis. FAIL if commitment is wholly deferred to the closing synthesis.
+
+(5) **Contrarian case engaged with substance.** Find the bear-case section or engagement. Is it a substantive paragraph (or more), representing the opposing view at its strongest? FAIL if dissent is dismissed in one sentence or strawmanned.
+
+(6) **Historical precedent present.** Find at least one analogous historical case used to ground the prediction. FAIL if the draft makes forward-looking claims with zero historical anchoring AND does not explicitly justify why the domain is unprecedented.
+
+(7) **Tier weighting.** Are forecast claims anchored in `ground_truth` tier sources? Is any load-bearing claim resting solely on `commentary`? FAIL if commentary is the sole support for a substantive prediction.
+
+(8) **Scaffold + comparisons + extract artifacts exist.** Run `$HPR search 'scaffold' -j`, `$HPR search 'comparisons' -j`, `$HPR note list --tag extract -j`. All non-empty. FAIL otherwise.
+
+(9) **Provenance chain.** Run `$HPR lint --rule provenance -j`. FAIL if any issues.
+
+(10) **Analyst coverage.** Run `$HPR lint --rule analyst-coverage -j`. FAIL if below 30%.
+
+(11) **Opening frames the decision + forces.** Does the opening state what is being forecast, why it is uncertain, and what 3–5 forces will determine the outcome? FAIL if the opening is a history lesson or a definition.
+
+(12) **Explicit "what would change my mind" statement.** Find a statement of what evidence would flip the forecast. FAIL if no such statement exists.
+
+(13) **No academic API sweep was run.** Confirm via vault tags — if the corpus is dominated by `paper` content_type sources, the agent ran the wrong source strategy. FAIL (non-critical — correct the source mix and re-run).
+
+Auditor output: list every violation with a one-line quote from the report.

--- a/src/hyperresearch/skills/research-synthesize.md
+++ b/src/hyperresearch/skills/research-synthesize.md
@@ -110,15 +110,20 @@ WebSearch("<topic> 批評 論文")              # Japanese
 
 Non-English sources count toward voice diversity at Checkpoint 1.
 
-### Adversarial round
+### Adversarial round — MANDATORY, run all four before proceeding
 
-Required. Find the strongest dissenting reading / dissenting mechanism explanation / dissenting theoretical position. Your thesis must engage it with substance, not a one-sentence dismissal.
+Find the strongest dissenting reading / dissenting mechanism explanation / dissenting theoretical position. Your thesis must engage it with substance, not a one-sentence dismissal. **Fetch at least one source that explicitly argues against the dominant interpretation.**
 
 ```
 WebSearch("<topic> criticism limitations")
 WebSearch("against <dominant reading> <topic>")
-WebSearch("<topic> reappraisal new reading")
+WebSearch("<topic> reappraisal revisionist new reading")
+WebSearch("<topic> overrated wrong contested")
 ```
+
+The audit at Step 11 verifies at least one body section engages the dissenting reading with substance (a paragraph or more, not a sentence). A synthesize draft built entirely from sources that agree with each other is advocacy — the corpus must contain the strongest counter-voice you could find, even if your draft ultimately rejects it.
+
+If the dominant reading has a named opponent (e.g., "the Lacanians say X but Žižek argues Y"), search for the opponent by name, not just by topic. Named-critic search produces sharper dissent than generic "criticism of X".
 
 ### Source diversity — at least one non-academic voice
 

--- a/src/hyperresearch/skills/research-synthesize.md
+++ b/src/hyperresearch/skills/research-synthesize.md
@@ -1,0 +1,216 @@
+---
+name: research-synthesize
+description: >
+  Interpretive and explanatory research. The user wants to know what
+  something MEANS, how it WORKS, or WHY it is the way it is. Primary virtue
+  is interpretation density — every paragraph fuses fact with an analytical
+  claim. Covers everything from literary/humanities interpretation to
+  conceptual explanation of scientific mechanisms.
+---
+
+# Synthesize Protocol
+
+> You are in **synthesize** modality. The dispatcher routed you here because the output needs a defended thesis or a mechanism explanation — not enumeration, not comparison, not prediction. The reader leaves with an argument they can be persuaded by or disagree with.
+
+Read the dispatcher (`.claude/skills/hyperresearch/SKILL.md`) for the process. This file is the SUBSTANCE reference for synthesize.
+
+---
+
+## What synthesize is for
+
+| Prompt shape | Why it's synthesize |
+|---|---|
+| "What does Blood Meridian's violence mean" | Thesis-driven interpretation |
+| "Explain how attention mechanisms work in transformers" | Mechanism explanation |
+| "Why did the Roman Republic collapse" | Causal / explanatory |
+| "What is Wittgenstein's private language argument and why does it matter" | Interpretive + conceptual |
+| "How does CRISPR-Cas9 edit DNA and what are its limitations" | Mechanism + critique |
+
+Synthesize is NOT for: "list all X" (collect), "which X is best" (compare), "will X happen" (forecast).
+
+**Two legitimate sub-shapes:**
+1. **Interpretive synthesis** — the subject is a text, work, tradition, cultural phenomenon, or philosophical position. The thesis is an interpretation. Sources are primary texts + established critical tradition + dissenting readings.
+2. **Mechanism synthesis** — the subject is a process, system, or phenomenon. The thesis is a mechanism explanation with WHY it works the way it does. Sources are peer-reviewed literature + authoritative technical references.
+
+The dispatcher picks synthesize when the output's primary virtue is *understanding*, regardless of which sub-shape applies.
+
+---
+
+## Source strategy
+
+### If a peer-reviewed literature exists — academic API sweep BEFORE web search
+
+For mechanism synthesis, or interpretive synthesis where scholarly criticism is the dominant tradition: run the academic APIs first. Web search returns derivative commentary; academic APIs return citation-ranked canonical papers.
+
+**Semantic Scholar** — citation count + forward/backward chaining:
+
+```python
+import httpx, json, urllib.parse, os, time
+SS_KEY = os.environ.get("SS_API_KEY", "")
+HEADERS = {"x-api-key": SS_KEY} if SS_KEY else {}
+q = urllib.parse.quote("<topic>")
+url = f"https://api.semanticscholar.org/graph/v1/paper/search?query={q}&fields=title,year,citationCount,externalIds&limit=10"
+r = httpx.get(url, headers=HEADERS, timeout=15).json()
+papers = sorted(r["data"], key=lambda p: p.get("citationCount", 0), reverse=True)
+# Top 3 → backward chain (references) AND forward chain (citations)
+for p in papers[:3]:
+    pid = p["paperId"]
+    refs = httpx.get(f"https://api.semanticscholar.org/graph/v1/paper/{pid}/references?fields=title,year,citationCount&limit=30", headers=HEADERS, timeout=15).json()
+    cits = httpx.get(f"https://api.semanticscholar.org/graph/v1/paper/{pid}/citations?fields=title,year,citationCount,isInfluential&limit=50", headers=HEADERS, timeout=15).json()
+    time.sleep(0.4)
+```
+
+Backward chaining finds the foundational canon; forward chaining finds everything built on it in the last 3 years.
+
+**OpenAlex** for humanities, social science, medicine, or non-arXiv disciplines:
+
+```
+https://api.openalex.org/works?search=<topic>&sort=cited_by_count:desc&per-page=15&mailto=research@example.com
+```
+
+**arXiv** for cs / stat / q-bio / econ / math / physics:
+
+```
+https://export.arxiv.org/api/query?search_query=cat:cs.LG+AND+all:<topic>&sortBy=relevance&max_results=25
+```
+
+**PubMed eutils** for biomedical / clinical:
+
+```
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=<topic>&retmode=json&retmax=20
+```
+
+Feed PDF links directly to `$HPR fetch` — the fetcher handles PDF extraction automatically.
+
+### If the subject has no peer-reviewed literature — start with primary sources + guided reading loop
+
+For interpretive synthesis of pop-culture / contemporary / niche subjects where scholarly criticism is thin or absent, skip the academic sweep. The source strategy is:
+
+**Ground truth:** the primary work itself (if available online; substantial excerpts if not), author/creator interviews stating intent, official materials.
+
+**Institutional signal:** named critical essays, longform analyses, scholarly monographs, Wikipedia references harvest (curated for notability).
+
+**Practitioner triangulation:** professional reviews, interviews with domain experts, conference keynote transcripts.
+
+**Commentary (de-prioritized):** listicles and YouTube reviews — lead-generation only, not load-bearing.
+
+Use the **guided reading loop** from the dispatcher as the default discovery mechanism. The critical tradition for interpretive subjects is discoverable only by reading — the essay names three critics, those critics cite a 1998 monograph, the monograph references a specific passage.
+
+### Non-English sources when the subject has non-English reception
+
+If the subject has major non-English reception (a franchise bigger in France than the US, a philosopher with denser German scholarship, a movement with foundational French literature), run searches in those languages:
+
+```
+WebSearch("<topic> análise crítica")      # Portuguese
+WebSearch("<topic> critique analyse")     # French
+WebSearch("<topic> analisi critica")      # Italian
+WebSearch("<topic> Kritik Rezeption")     # German
+WebSearch("<topic> 批評 論文")              # Japanese
+```
+
+Non-English sources count toward voice diversity at Checkpoint 1.
+
+### Adversarial round
+
+Required. Find the strongest dissenting reading / dissenting mechanism explanation / dissenting theoretical position. Your thesis must engage it with substance, not a one-sentence dismissal.
+
+```
+WebSearch("<topic> criticism limitations")
+WebSearch("against <dominant reading> <topic>")
+WebSearch("<topic> reappraisal new reading")
+```
+
+### Source diversity — at least one non-academic voice
+
+If the subject has practitioners (applied economists, engineers, policy analysts, industry users, operators), **at least one non-academic voice is mandatory.** A synthesize corpus built entirely of peer-reviewed papers plus lecture notes is a monoculture — the thesis loses its grip on reality when nobody in the corpus has actually *used* the thing.
+
+Examples of required non-academic voices:
+- "Is there a general method for solving first-price auctions?" — the academic corpus says "here are 5 methods"; an applied voice (FTC economist blog, procurement handbook, named practitioner postmortem) tells you whether any of them is actually used in the wild.
+- "How does CRISPR edit DNA?" — the academic papers explain the mechanism; a biotech industry voice (Moderna process description, patent litigation commentary) tells you which off-target effects matter in production.
+- "What does Blood Meridian mean?" — the scholarly tradition sets the interpretive axes; a named critic blog or longform essay brings the thesis into the present.
+
+Search for these explicitly:
+
+```
+WebSearch("<topic> in practice applied industry")
+WebSearch("<topic> practitioner guide used by")
+WebSearch("<topic> does anyone actually use")
+```
+
+If no such voice exists (genuinely novel topic, purely theoretical subject), state that explicitly in the scaffold and explain why — otherwise Checkpoint 1 flags the corpus as under-diverse.
+
+---
+
+## Substance rules for Step 9 (writing)
+
+These are the synthesize-specific rules that layer on top of the dispatcher's shared writing constraints.
+
+### 1. Commit to a thesis
+
+The draft is built around ONE defensible claim: what you are arguing about the subject. State it clearly — ideally in a single short sentence in the opening — then spend the draft defending it.
+
+A thesis is NOT a summary ("Blood Meridian is about violence"). A thesis is an arguable position ("Blood Meridian's violence is structural, not expressive — it enacts a theological claim that human agency is a ventriloquism of geology"). A neutral reader could read your thesis and disagree.
+
+### 2. Interpretation density — every paragraph fuses fact with claim
+
+Every body paragraph must do both: report a fact / quote / source AND make an interpretive claim about what the fact MEANS within your thesis. A paragraph that only reports facts is a textbook excerpt, not synthesis.
+
+**Bad:** "Transformers use a self-attention mechanism. The mechanism computes a weighted sum where weights come from query-key similarity."
+
+**Good:** "Transformers use self-attention — but the substantive move is not the attention itself, it is what attention *replaces*. Recurrence imposes a temporal bottleneck: position N can only reach position N-1 through the sequence of hidden states. Self-attention obliterates this bottleneck and treats the sequence as a set, which is why transformers scale but LSTMs don't. The mechanism is a structural concession, not just an engineering trick."
+
+Every paragraph earns its place by advancing the thesis or complicating it — not by restating source material.
+
+### 3. Engage the strongest dissent
+
+Find the reading / explanation / theoretical position that most directly contradicts your thesis. Give it substantive engagement — at minimum a full paragraph, ideally a full section. Represent it at its strongest, not strawmanned. Then explain why you reject it.
+
+A thesis that never engages its opposite is advocacy, not argument.
+
+### 4. Sources in tension at least twice
+
+At least two body sections must put specific sources in direct tension: "Smith reads this passage as X; Jones reads it as Y. The textual evidence supports Z because..." This is the mark of synthesis — the reader sees you weighing evidence, not just citing it.
+
+### 5. Quote the primary source directly
+
+When the synthesis is interpretive, quote the primary work. Claim → direct quote → analysis of what the quote means. Paraphrase only when quotation is impossible or redundant.
+
+When the synthesis is mechanism-explanation, quote the canonical paper's own description of the mechanism before you extend it.
+
+### 6. Opening establishes the thesis AND the core tension
+
+The opening answers: *what am I claiming, and why is this claim non-trivial*. If the thesis is obvious, the draft has no reason to exist. Name the tension: the paradox, the received view you're pushing against, the open problem, the tradeoff. That's the engine that drives the rest of the draft.
+
+### 7. Section progression tracks the argument
+
+Sections build on each other. Section 2's claim depends on section 1's setup; section 3 complicates section 2; the dissenting-view section is placed where the argument is strongest, so the reader feels the weight of the opposition before they see your counter. A shuffled set of thematic sections is not synthesis — it is a collage.
+
+---
+
+## Conformance checks (auditor reads this at Step 11, mode=conformance)
+
+(0) **Verbatim prompt check.** Open `research/scaffold.md` — does its first section contain the user's verbatim prompt (unchanged, not paraphrased)? FAIL if missing or modified.
+
+(1) **Thesis exists and is arguable.** Read the opening. Is there a clear thesis sentence? Is it a position a neutral reader could disagree with (not a neutral summary)? FAIL if the draft never commits to a claim.
+
+(2) **Interpretation density.** Sample 5 random body paragraphs. For each: does it fuse a factual / source claim with an interpretive claim about what the fact means? FAIL any paragraph that is pure description or pure source-citation without an analytical move.
+
+(3) **Dissenting view engaged substantively.** Find the section that engages the strongest opposing reading / explanation. Is the opposing position given a substantive paragraph (or more)? Is it represented at its strongest? FAIL if dissent is dismissed in one sentence or strawmanned.
+
+(4) **Sources in tension at least twice.** Count body sections where specific sources are put in direct tension. FAIL if fewer than two.
+
+(5) **Primary sources cited directly.** For interpretive synthesis: are there at least 3 direct quotations from the primary work? For mechanism synthesis: is the canonical source's own description of the mechanism quoted before the explanation extends it? FAIL if the draft only paraphrases.
+
+(6) **Section progression.** Can sections be shuffled without loss? If yes, the draft is a collage, not an argument. FAIL.
+
+(7) **Scaffold + comparisons + extract artifacts exist.** Run `$HPR search 'scaffold' -j`, `$HPR search 'comparisons' -j`, `$HPR note list --tag extract -j`. All must return non-empty. FAIL otherwise.
+
+(8) **Provenance chain.** Run `$HPR lint --rule provenance -j`. FAIL if any issues.
+
+(9) **Analyst coverage.** Run `$HPR lint --rule analyst-coverage -j`. FAIL if below 30%.
+
+(10) **Tier weighting.** Are substantive claims anchored in `ground_truth` or `institutional` sources? Are load-bearing claims ever supported only by `commentary`? FAIL if any load-bearing claim rests solely on derivative commentary.
+
+(11) **Core tension present in opening.** Does the opening state what makes the thesis non-trivial (the paradox, received view being pushed against, open problem)? FAIL if the opening is a neutral setup.
+
+Auditor output: list every violation with a one-line quote from the report.

--- a/src/hyperresearch/skills/research.md
+++ b/src/hyperresearch/skills/research.md
@@ -237,7 +237,7 @@ For high-priority failures, work through this fallback chain in order — stop a
    - SSRN, RePEc, NBER, OpenAlex, Semantic Scholar mirror
    - Google Scholar's "All N versions" link
 2. **Try the visible-browser flag** on the original URL: `$HPR fetch "<url>" --visible ...`. The `--visible` flag runs the browser non-headless; many sites that block headless requests succeed when the browser is visible. Cost: ~5-10s slower per fetch.
-3. **Try the user's authenticated profile** if one is configured: `$HPR fetch "<url>" --profile research ...`. Login profiles bypass paywalls on sites the user has logged into. If no profile is configured, the user can create one via `hyperresearch setup`.
+3. **If a login profile is configured for this vault** (`.hyperresearch/config.toml` has a `[web] profile = "<name>"` entry), crawl4ai uses it automatically — paywalled sites the user has logged into in that profile will succeed transparently. If profile-protected sites still fail, the profile may be expired; tell the user to re-run `hyperresearch setup` to refresh it. There is no `--profile` CLI flag — it's a per-vault config setting.
 4. **As a last resort**, search for a **summary or review** of the paper that captures its key claims (e.g., a textbook chapter that summarizes the result). Note this in the source's frontmatter `summary:` field as `(via summary, original PDF unavailable)`.
 5. **If all four fail and the source is genuinely irreplaceable**, surface the failure to the user — don't ship a draft that depends on a source you couldn't read.
 

--- a/src/hyperresearch/skills/research.md
+++ b/src/hyperresearch/skills/research.md
@@ -1,526 +1,715 @@
 ---
 name: research
 description: >
-  Deep research on any topic. Searches the web, fetches sources with a headless browser,
-  follows links to primary sources, builds a searchable knowledge base, and synthesizes
-  findings. Use when the user asks to research, investigate, or learn about a topic.
+  Deep research on any topic. Classifies requests by cognitive activity
+  (collect / synthesize / compare / forecast), not subject matter. Produces
+  a sourced, adversarially-audited report with full data-flow provenance.
   Trigger: /research
 ---
 
-# Deep Research Skill
+# Research Dispatcher
 
-## Step 0: Clarify the request
+The research protocol has ONE process spine (this file) and FOUR modality files that encode substance differences. Read this file end-to-end. Then read the modality file the classifier routes you to. Both are required.
 
-Before doing ANY research, evaluate the user's request. If it is vague, ambiguous, or could go in multiple directions, **ask clarifying questions first**. Do not guess — ask. Examples:
+**There are no numeric targets in this protocol.** No word counts, no H2 counts, no words-per-section floors. A draft is as long as the substance demands and as short as the structure allows. The user's own scope cues (if any) are the only length guidance that applies.
 
-- "Research AI models" → Ask: "Which aspect? Training techniques, specific architectures, benchmarks, a particular company's models, deployment strategies?"
-- "Find out about this company" → Ask: "What specifically? Financials, leadership, products, tech stack, culture, recent news?"
-- "Look into transformers" → Ask: "The neural network architecture, or a specific variant? Are you interested in the theory, practical implementation, or recent alternatives like Mamba?"
-
-Ask 1-3 focused questions. Once you understand the scope, proceed. If the request is already specific and clear, skip this step and start researching immediately.
-
-## Step 0.5: Classify the request and pick a protocol (MANDATORY)
-
-Different research requests need fundamentally different strategies. Source counts, primary/secondary mix, section structure, target length, analytical mode — all change based on the request shape. A single universal protocol is wrong. **Before Step 1, classify the request into one of the 7 types below and state your classification in writing** (in working memory or `/tmp/scaffold.md` — NOT a hyperresearch note).
-
-### The 7 request types
-
-| Type | Name | Use when |
-|---|---|---|
-| 1 | **Canonical Knowledge Retrieval** | Mature field with textbook chapters or canonical survey papers; a domain expert would start by citing a classic source. |
-| 2 | **Market / Landscape Mapping** | Enumerable competitive analysis — list of companies, products, vendors with attributes. |
-| 3 | **Engineering / Technical How-To** | User is trying to DO something. Ideal answer is a procedure or method selection. |
-| 4 | **Interpretive / Humanities Analysis** | Subject is a text, work, tradition, or cultural phenomenon. Good answer takes a position and defends it. |
-| 5 | **Comparative Evaluation** | Prompt names multiple alternatives by name and expects a matrix + pick. |
-| 6 | **Emerging / Cutting-Edge Research** | Most useful material is <2 years old; best sources are arXiv/bioRxiv/conference papers. |
-| 7 | **Forecast / Strategy / Recommendation** | Asks what will happen or what should be done; ideal answer commits to a prediction or prescription. |
-| 0 | **General Research (fallback)** | Doesn't cleanly fit one type, or genuinely spans multiple. |
-
-Overlap is expected. Classify a **primary** type and, if applicable, a **secondary** type. Apply the parameter block for the primary; borrow special rules from the secondary.
-
-### State your classification
-
-Before Step 1, write this down:
-
-1. **Primary type**: #N — one-sentence justification tied to the prompt.
-2. **Secondary type**: #N or "none".
-3. **Applied parameters** (5 lines): source strategy, target length, opening-section shape, target H2 count, analytical mode.
-
-Refer back to this throughout the workflow. It's how you avoid drifting into one-size-fits-all defaults.
+**The user's verbatim prompt is the only gospel in this session.** It gets copied into the scaffold at Step 7 and every subsequent step re-reads it. Whenever you are unsure what to do, re-read the prompt. Whenever the draft feels like it's drifting, re-read the prompt. The auditor at Step 11 grades the draft against the verbatim prompt — not against any abstract notion of quality.
 
 ---
 
-## Request-type parameter blocks
+## The 4 activities
 
-Pick the block for your primary type and apply it. These **override** the generic defaults in Step 3 (source count) and Step 9 (writing constraints).
+Research requests are classified by what the output needs to DO, not what the subject IS.
 
-### Type 1 — Canonical Knowledge Retrieval
+| Activity | Question it answers | Primary virtue | Modality file |
+|---|---|---|---|
+| **collect** | "What exists / what happened / who did what" | Exhaustive enumerative coverage with per-entity fields | `.claude/skills/hyperresearch/SKILL-collect.md` |
+| **synthesize** | "What does it mean / how does it work / why" | Interpretive density — a defended thesis grounded in evidence | `.claude/skills/hyperresearch/SKILL-synthesize.md` |
+| **compare** | "Which is better for what / how do they differ" | Proportionate per-entity depth + a committed recommendation | `.claude/skills/hyperresearch/SKILL-compare.md` |
+| **forecast** | "What will happen / what should we do" | Committed prediction from past + current state with explicit time horizon | `.claude/skills/hyperresearch/SKILL-forecast.md` |
 
-- **Source strategy:** 5–15 primary (seminal papers, textbooks, canonical surveys) + 5–15 secondary (recent reviews, textbook chapters). Primary-heavy. Read primary DEEP.
-- **Target length:** 6,000–10,000 words
-- **Opening:** historical / conceptual progression — how the field arrived at current consensus
-- **H2 count:** 10–15, sequenced by dependency (concept → result → consequence)
-- **Analytical mode:** explain WHY canonical results hold; compare competing formulations; signal which textbook to start with
-- **Special rule:** sequence content by dependency, not by source. A reader should need sections 1 and 2 to understand section 3.
+**Subject matter does not decide the classification.** A query about a fictional franchise can be collect (per-character enumeration), synthesize (a thesis about what the franchise means), compare (this franchise vs another), or forecast (will this franchise's new arc succeed). A query about distributed databases can be any of the four. The classifier reads what the output should *do*, not what the subject *is*.
 
-### Type 2 — Market / Landscape Mapping
-
-- **Source strategy:** 20–50 secondary (analyst reports, press, official docs) + 5–10 primary (filings, product specs, API docs). Secondary-heavy — triangulation across many descriptions is correct here.
-- **Target length:** 5,000–9,000 words
-- **Opening:** market definition + segmentation + the framework used to score vendors
-- **H2 count:** 8–14, one per vendor *cluster* or category — NEVER one per individual vendor
-- **Analytical mode:** take a position on who is winning and why
-- **Special rule:** at least one comparison matrix in the body, with common axes, is MANDATORY. Never list vendors in isolation.
-- **Special rule:** if the user asked for rankings, deliver them with confidence. Rankings without commitment are worthless.
-
-### Type 3 — Engineering / Technical How-To
-
-- **Source strategy:** 5–15 primary (papers, docs, GitHub repos, RFCs, standards) + 5–15 secondary (blog posts, tutorials, StackOverflow). Roughly balanced.
-- **Target length:** 4,000–8,000 words
-- **Opening:** the problem statement + the constraint landscape — what makes this hard, why naive approaches fail
-- **H2 count:** 8–14
-- **Analytical mode:** pick a recommended approach; explain when to use alternatives
-- **Special rule:** if a method has a reference implementation, link it and characterize it
-- **Special rule:** include a decision tree or selection matrix ("use X when..., use Y when...")
-
-### Type 4 — Interpretive / Humanities Analysis
-
-- **Source strategy:** 3–10 primary (the work itself, key scholarly monographs, canonical commentary) + 10–25 secondary (critical essays, interviews, reviews). Primary-heavy for depth.
-- **Target length:** 7,000–11,000 words
-- **Opening:** thesis + the interpretive tradition this work sits in
-- **H2 count:** **6–10** (fewer, LONGER sections — 800–1500 words each). Sections are THEMATIC, not entity-cataloged.
-- **Analytical mode:** take and defend an interpretation; engage dissenting readings
-- **Special rule:** NEVER one section per character / chapter / author. Sections must be thematic (e.g. "Sacrifice as cosmology" — not "Pegasus Seiya").
-- **Special rule:** at least 2 body sections must put sources in tension with each other — find where scholars disagree and walk through it.
-- **Special rule:** this is the type where catalog-style reports fail hardest. Before submitting, double-check that no section is <400 words or entity-named.
-
-### Type 5 — Comparative Evaluation
-
-- **Source strategy:** 3–5 primary per comparand + 2–5 secondary per comparand (so N×5 to N×10 total). Depth scales with N.
-- **Target length:** 5,000–10,000 words
-- **Opening:** the comparison framework itself — the dimensions being scored and why they matter
-- **H2 count:** typically 1 per comparand + 2–4 synthesis sections (~8–12 total)
-- **Analytical mode:** explicit scoring on each dimension + a recommended pick with tradeoffs
-- **Special rule:** one comparison matrix in the body is MANDATORY (not optional)
-- **Special rule:** equal depth across comparands — if one section is 400 words and another is 1200, rebalance
-
-### Type 6 — Emerging / Cutting-Edge Research
-
-- **Source strategy:** 5–15 primary (preprints, conference papers, authoritative reviews if any) + 3–8 secondary (news, blog posts from authors). Primary-dominant.
-- **Target length:** 5,000–9,000 words
-- **Opening:** the open problem + why prior approaches fell short
-- **H2 count:** 8–12
-- **Analytical mode:** honest about disagreement; forecast 2–5 years out with caveats
-- **Special rule:** if a claim is from a 2024–2026 preprint, say so. Don't assume consensus in fast-moving fields.
-- **Special rule:** include an explicit "What we don't know yet" section
-- **Special rule:** do NOT pad with mature-field material to hit a source count. Fewer primary sources deeply engaged beats more sources shallowly skimmed.
-
-### Type 7 — Forecast / Strategy / Recommendation
-
-- **Source strategy:** 15–30 secondary (analyst reports, think-tanks, news) + 5–10 primary (official announcements, filings, datasets). Secondary-heavy.
-- **Target length:** 6,000–10,000 words
-- **Opening:** the decision / question being answered + the forces shaping it
-- **H2 count:** 8–12
-- **Analytical mode:** confident prescription with an explicit reasoning chain. Probability language over hedging.
-- **Special rule:** at least one body section must commit to a direction — not everything can be deferred to the Opinionated Synthesis at the end.
-- **Special rule:** acknowledge the time horizon explicitly — what's true in 6 months vs. 5 years.
-
-### Type 0 — General Research (fallback)
-
-Use the generic defaults: 15–25 / 30–50 / 50–80 source floors (see Step 3), framework opening, 12–20 H2 headings, 400–600 words per H2 (see Step 9).
+**A single prompt can blend activities** — that is normal. Pick ONE primary and optionally ONE secondary flavor. The primary determines the process and the structural backbone; the secondary informs the substance rules at Step 9. Example: "Analyze Saint Seiya's armor classes: for each significant character, cover techniques, story arcs, fate — and develop a thematic argument about what the armor means" is **collect** (primary — the per-character enumeration is the backbone) + **synthesize** (secondary — thematic beats layered into each entity section).
 
 ---
 
-When invoked, follow these steps **in order**. Do not skip steps. The CLI path will be provided by the CLAUDE.md — look for the "CLI path:" line in the Research Base section.
+## Step 0: Clarify if vague
 
-If you can't find the CLI path, check for the hyperresearch executable:
-```bash
-which hyperresearch 2>/dev/null || where hyperresearch 2>/dev/null || find . -path "*/.venv/*/hyperresearch*" -type f 2>/dev/null | head -1
-```
-Store it in a variable: `HPR="<path>"` for the rest of this workflow.
+If the request is vague or ambiguous, ask 1–3 focused questions before proceeding. Don't guess.
 
-## Step 1: Check existing knowledge
+---
 
-Before searching the web, check what's already in the research base:
+## Step 0.5: Check existing vault coverage first
 
 ```bash
-$HPR search "<topic>" --include-body -j
-$HPR sources list -j
+$HPR search "<topic>" -j
 ```
 
-If there's already substantial coverage, tell the user what's known and ask if they want deeper research or a specific angle.
+If the vault already has >10 relevant notes: tell the user, summarize what's there, and ask whether they want deeper research, a specific angle, or synthesis from existing notes. Don't re-fetch what's already curated.
 
-## Step 2: Search broadly
+---
 
-Run **multiple web searches** with different phrasings. Don't stop at one query:
+## Step 1: Classify + commit the verbatim prompt
+
+State your classification in writing BEFORE doing anything else. Copy the user's prompt verbatim into your working memory. This is the format you MUST output:
+
+```markdown
+## User Prompt (VERBATIM — gospel)
+> [paste the entire user message here, character-for-character. Do not
+> paraphrase. Do not summarize. Do not reformat. This text is the only
+> authoritative source for what the output should contain and look like.]
+
+## Primary activity
+<collect | synthesize | compare | forecast>
+
+## Secondary flavor (optional)
+<collect | synthesize | compare | forecast | none>
+
+## One-sentence justification
+<why this primary activity matches what the output needs to DO>
+
+## What the user explicitly asked for (extracted from the verbatim prompt)
+- **Explicit deliverables:** <list every specific ask — "answer A, B, C", "include a recommendation", "for each X give Y" — or "none">
+- **Explicit entities or items:** <every item named in the prompt, or "none">
+- **Explicit per-item fields:** <every field the prompt demands per entity — "power level / technique / fate" — or "none">
+- **Explicit structure:** <"one section per", "ranked list", "executive summary", etc., or "silent">
+- **Explicit format:** <prose / bullets / table / code / FAQ, or "silent">
+- **Explicit scope cues:** <"brief", "detailed", "deep dive", specific lengths, or "silent">
+- **Explicit ordering:** <chronological / by importance / custom, or "silent">
+
+## Core tension
+<what makes this question non-trivial — a paradox, a disagreement, a tradeoff,
+a constraint interaction, an open problem. One-to-three sentences. This is
+what the draft must earn its way through.>
+```
+
+Then **read the corresponding modality file with the Read tool.** The modality file tells you HOW to do the activity-specific parts (source strategy, substance rules, conformance checks). This dispatcher tells you WHAT steps to run and in what order.
+
+---
+
+## Tiebreaker questions
+
+When two activities seem equally applicable:
+
+**collect vs compare** — Does the user want coverage ("tell me everything") or evaluation ("which is best")? Recommendation expected or entities set against each other → **compare**. Coverage is the point and no recommendation is requested → **collect**.
+
+**collect vs synthesize** — Does the output need a defended thesis or just complete coverage? If the user explicitly asks for interpretation, meaning, or analysis alongside enumeration, the primary is usually **collect** (the enumeration is the dominant ask) and the secondary flavor is **synthesize**. Pure enumeration without thesis → **collect**. Pure thesis without per-entity coverage → **synthesize**.
+
+**synthesize vs forecast** — Is the claim about what IS (how it works, what it means) or what WILL BE (prediction, recommendation)? Past/present → **synthesize**. Future → **forecast**.
+
+**compare vs forecast** — Is the user asking which option is best NOW or which will be best LATER? Now → **compare**. Later → **forecast** (often with compare flavor).
+
+**Any activity when the prompt contains "for each X, provide Y / Z / W"** — The explicit per-entity field list is a collection contract. Route to **collect** as the primary regardless of subject, with any interpretive / comparative / predictive framing as secondary flavor. The per-entity contract takes precedence because it is the most specific kind of user mandate.
+
+---
+
+## Prompt fidelity — the gospel rule
+
+**Re-read the user's verbatim prompt at every checkpoint.** The prompt is inside the scaffold (Step 7). Every checkpoint re-opens the scaffold. Every time you re-open the scaffold, re-read the prompt first. Every structural decision must trace back to the prompt or a modality default that the prompt is silent on.
+
+- If the prompt specifies structure / format / entities / fields / ordering / scope: **the user's request is authoritative**. Modality defaults yield.
+- If the prompt is silent on any of those: **the modality default applies** to what the prompt left open.
+- The modality file is authoritative for SUBSTANCE (interpretation density, proportionate depth, probability language, mechanism clarity). Substance rules hold regardless of shape.
+
+**Never negotiate the user's contract.** If the user asked for 108 entities and 4 fields each, you owe 108 × 4 data points. You do NOT get to substitute "representative examples + thematic commentary". You do NOT get to silently downgrade "each" to "the most important". If the user's contract seems impossible to satisfy within a reasonable draft, surface that tension to the user and ask — do not paper over it by producing less than what was asked.
+
+---
+
+## Process discipline (applies to every activity)
+
+This protocol is **process-driven**. Each required step produces an **artifact** that a later step reads. Skipping a step does not save work — it breaks the dependency chain silently, and the later step operates on missing-but-pretended input. The draft then gets written without the tension analysis; the audit never fires; the report ships un-stress-tested.
+
+**Definition of task failure:** if a required artifact does not exist on disk or in the vault at the checkpoint where the next step expects it, the task has FAILED at that checkpoint. Failure is not fatal — it means: STOP the current step, return to the step that produces the missing artifact, complete it, and re-run the checkpoint. You may NOT compensate for a missing artifact by doing extra work inside the step that follows it.
+
+Read this section before doing anything else, then follow it literally. You will self-review four times in a single research session. If any review fails, you go back.
+
+### Required TODO list (build this immediately after Step 1 classification)
+
+Before executing Step 2, create this exact TODO list with the TodoWrite tool. Do NOT fetch anything, search anything, or write anything until the list exists:
+
+1. Check existing vault coverage (Step 0.5)
+2. Discover sources (Step 2)
+3. Fetch source batch or open the guided reading loop (Step 3)
+4. **Checkpoint 1: post-fetch review**
+5. Rabbit-hole pass with `--suggested-by` provenance (Step 4)
+6. Curate every source: tier + content_type + summary + analyst extract (Steps 5–6)
+7. Run link / lint / graph hubs (Steps 5–6)
+8. **Checkpoint 2: post-curate review**
+9. Write scaffold note WITH verbatim user prompt as first section (Step 7)
+10. Write comparisons note (Step 8)
+11. **Checkpoint 3: pre-draft gate — CRITICAL**
+12. Write `research/notes/final_report.md` (Step 9)
+13. Gap analysis + adversarial search (Step 10)
+14. Adversarial audit via `hyperresearch-auditor` — both modes in parallel (Step 11)
+15. **Checkpoint 4: post-audit review**
+16. Write Opinionated Synthesis section (Step 12)
+17. Save synthesis note + health checks (Steps 13–14)
+
+Mark each item `completed` only after its artifact exists AND you have verified it exists with a command. You may NOT mark item 12 (the draft) `in_progress` until items 1–11 are all `completed`. The TODO list is the process ledger.
+
+---
+
+## Zettelkasten conventions (apply in every activity)
+
+All notes follow atomic Zettelkasten conventions. The CLI manages the index.
+
+**Note `type:` field:** `source` | `synthesis` | `moc` | `scaffold` | `comparison`
+
+**Status lifecycle:** `draft` → `review` → `evergreen` → `stale` → `deprecated` → `archive`
+
+**Every source note must have:** `title`, `source` (URL), at least one `tag`, `summary` (≤120 chars), `status`, `tier`, `content_type`.
+
+**Epistemic metadata (required on every source note before Checkpoint 2):**
+
+- **`tier`** — what epistemic role this source plays:
+  - `ground_truth` — the artifact itself: official filings, product specs, datasets, primary texts, peer-reviewed papers with original data, regulatory text
+  - `institutional` — authoritative synthesizers: analyst reports, think-tanks, review/survey papers, textbooks, canonical criticism
+  - `practitioner` — how domain participants actually experience it: user reviews, community threads, practitioner blogs, postmortems, migration guides
+  - `commentary` — discussion without new signal: news summaries, opinion pieces, derivative explainers
+  - `unknown` — unclassified (default at fetch time; must be replaced during curation)
+- **`content_type`** — what kind of artifact this is: `paper` | `docs` | `article` | `blog` | `forum` | `dataset` | `policy` | `code` | `book` | `transcript` | `review` | `unknown`
+
+Tier and content_type are orthogonal: a `paper` can be `ground_truth` (original data) or `institutional` (a review). A `blog` can be `practitioner` (named engineer's postmortem) or `commentary` (derivative explainer).
+
+**Tagging:** Check existing tags first (`$HPR tags -j`). Reuse existing tags. Apply multiple relevant tags per note. Do not invent synonyms.
+
+**Wiki-links:** Connect related notes with `[[note-id]]`. Every note should link to at least one sibling.
+
+---
+
+## Step 2: Source discovery
+
+The modality file tells you the source strategy (what APIs to hit, what source types to prioritize, whether to run the academic sweep). Run it.
+
+Then, regardless of modality, run an **adversarial search round** — searches that specifically look for the failure case, the dissenting view, the critique, the contrarian, the known limitations. Every activity needs this:
 
 ```
-WebSearch("<topic>")
-WebSearch("<topic> research paper 2025 2026")
-WebSearch("<topic> deep dive technical")
-WebSearch("<related angle or subtopic>")
+WebSearch("<topic> criticism limitations problems")
+WebSearch("<topic> against the grain dissenting view")
+WebSearch("why <dominant view> is wrong")
 ```
 
-Collect ALL promising URLs — aim for 10-20 sources minimum. More is better. You'll prune later.
+A corpus without dissent is advocacy, not research. If the adversarial round returns nothing substantive, note that explicitly — it is itself a finding.
 
-## Step 3: Fetch everything
+---
 
-Spawn `hyperresearch-fetcher` subagents to fetch URLs in parallel. They run on Haiku (cheap).
+## Step 3: Fetch — guided reading loop (preferred) or batch
+
+**Default: the guided reading loop** (described below). Seed with 3–5 high-signal URLs, then let each iteration's analyst subagents propose next targets based on what the prior sources cite.
+
+**Batch fetch** only when the target set is already known and complete — e.g., the user handed you 10 URLs, or the modality file says to batch (compare activity with explicitly-named entities is the usual case).
+
+### Guided reading loop protocol
+
+The loop is a bounce between fetching and reading:
 
 ```
-Spawn hyperresearch-fetcher agents for each URL batch:
-- Batch 1: [url1, url2, url3, url4, url5]
-- Batch 2: [url6, url7, url8, url9, url10]
+fetch 3-5 seeds  →  hyperresearch-analyst reads each with goal in hand  →
+  analyst returns extract + "next_targets" (URLs, queries, names, claims to verify)  →
+  main agent fetches next_targets with --suggested-by flag  →
+  hyperresearch-analyst reads those  →  ...
 ```
 
-Each fetcher will report back with note IDs and interesting links found in the content.
+Each iteration is a research director: the analyst reads one source, proposes what to read next, and hands the decision back to the main agent. This discovers source trees you couldn't find by keyword search alone — the essay names three critics, those critics cite a 1998 monograph, the monograph references a specific passage in the primary work.
 
-**Over-collect, then engage deeply.** It's better to have too many sources than too few — but collection is a means to an argument, not the goal. A report built from 30 sources that disagree and force you to take positions beats a report built from 80 sources that each contribute one bullet of description. Read each source carefully. If you find yourself translating one source into one paragraph or one section, stop — you are building a catalog.
+**Phase 1 — Seed fetch.** Pick the 3–5 highest-signal URLs:
+- 1–2 canonical reference entries (Wikipedia, field survey, official docs)
+- 1–2 analytical/critical sources visible in search results
+- 0–1 adversarial/dissenting source
 
-**There is no time limit.** Do multiple rounds of fetching — as new subtopics and questions reveal themselves, launch new rounds of fetcher subagents in parallel to chase them down. The first round uncovers the landscape, the second digs into what you found, the third fills gaps. Keep going until you've exhausted the topic. Do not rush.
+Spawn `hyperresearch-fetcher` on ONLY those 3–5. Do NOT batch-fetch 20 URLs upfront — half get wasted on sources the loop would tell you to skip.
 
-**CHECKPOINT: Before writing any draft, stop and take stock:**
+**Phase 2 — Guided reading iterations.** For each fresh note, spawn the **`hyperresearch-analyst`** agent (Sonnet, registered at `.claude/agents/hyperresearch-analyst.md`) with `mode=guided`:
+
+```
+research_goal: <the user's original verbatim prompt>
+sub_goal: <what this specific source should contribute>
+source_note_id: <the id of the note to read>
+mode: guided
+already_covered: <sub-topics prior iterations answered, or "none">
+already_fetched_urls: <output of `$HPR sources list -j`>
+```
+
+Spawn multiple analysts in parallel — one per source in the current batch. Each returns: extract content + covered sub-topics + 2–5 next_targets + coverage status.
+
+**Phase 3 — Main agent orchestration.** After each iteration returns:
+
+1. **Track the iteration in TodoWrite.** Add `Iteration N: fetch [targets] from [sources]`. After it completes, mark with the coverage delta ("added 4 sources, 2 sub-topics newly covered"). This makes stalls visible.
+2. Collect every extract into a running knowledge accumulator.
+3. Merge and dedupe next_targets across all analysts. If three subagents propose the same URL, fetch it once — pass all three suggesting source IDs via repeated `--suggested-by` flags.
+4. Prioritize next_targets by: (a) which would most likely *change* the argument if they disagreed with current sources, (b) which sub-topics the corpus doesn't yet cover, (c) which tiers are missing.
+5. **Fetch the top 3–5 next_targets WITH `--suggested-by` flag. This is mandatory:**
+
+   ```bash
+   $HPR fetch "<url>" \
+     --tag <topic> \
+     --suggested-by <source-note-id-1> \
+     --suggested-by <source-note-id-2> \
+     --suggested-by-reason "<the analyst's justification>" \
+     -j
+   ```
+
+   Without this flag the data-flow chain breaks — the fetched note has no link back to the source that found it, and you cannot trace how the research graph assembled itself.
+
+   **Graceful duplicate handling:** if the URL is already in the vault, fetch will NOT error. It appends the breadcrumb to the existing note and returns `{ok: true, duplicate: true, backlinks_added: N}`. Fetch every next_target; let fetch handle dedup.
+
+6. Refresh `already_fetched_urls` (`$HPR sources list -j`). Pass it to the next iteration.
+7. Spawn `hyperresearch-analyst` on the new notes. Loop.
+
+**Phase 4 — Termination.** Exit when ANY of these fires:
+- **Coverage complete** — all analyst returns report `coverage: complete` for the sub-topics you need.
+- **Cycle detected** — next_targets repeat or every proposed target's fetch returns `duplicate: true` with `backlinks_added: 0`.
+- **Diminishing returns** — a full iteration adds zero new sub-topics. The TodoWrite delta tracker catches this.
+- **Iteration cap: 5 full loops** — more than this and the loop is drifting, not converging. Stop and move on.
+
+Then proceed to curation (Steps 5–6).
+
+---
+
+## Step 4: Rabbit holes — follow what sources point at
+
+Beyond the guided loop's automated next_targets, actively scan fresh notes for:
+
+- **Cited datasets / primary data** → fetch the original, not the summary
+- **Named scholars / practitioners / companies** → find their own writing
+- **Referenced historical cases / precedents** → fetch the case itself
+- **Interviews or quotes** → find the full transcript
+
+Every manual rabbit-hole fetch MUST also pass `--suggested-by` naming the source that sent you there:
+
 ```bash
-$HPR note list -j
-```
-Review what you have. Don't chase a number — chase completeness:
-- What angles or subtopics are NOT yet covered?
-- Which notes reference sources you haven't fetched?
-- Are there counterarguments or alternative viewpoints missing?
-- Do you have primary sources or just secondhand summaries?
-
-If there's more to get, go get it. **Source count is a function of request type, not topic complexity** — use the parameter block from Step 0.5 (your classified primary type) as your primary guidance. Fall back to the universal floors below ONLY if you classified as Type 0 General Research:
-- Simple factual question: ~15–25 sources
-- Complex or technical topic: ~30–50 sources
-- PhD-level research question: ~50–80 sources
-
-**Primary-heavy vs. secondary-heavy is the axis that matters most — getting this wrong is a worse failure than getting the count wrong.** "Primary" means the claim comes from first-hand: an original paper, an official document, a dataset, a product spec. "Secondary" means any description or discussion of a primary source. Types 1, 4, 5, 6 are primary-heavy — cite originals, engage with them deeply, prune irrelevant secondary coverage. Types 2, 7 are secondary-heavy — triangulate across many descriptions because no single secondary source is authoritative. Type 3 is balanced.
-
-Stop fetching when you can't find anything new worth adding, not when you hit a number. And be honest about the opposite failure: if you're still fetching past the type's range without a clear gap in mind, you're procrastinating on the writing.
-
-## Step 4: Go down rabbit holes
-
-Read the fetched notes and follow links to deeper material:
-
-```bash
-$HPR note show <note-id> -j
+$HPR fetch "<url>" \
+  --tag <topic> \
+  --suggested-by <source-note-id> \
+  --suggested-by-reason "<one-line reason>" \
+  -j
 ```
 
-For each note, look for:
-- **Papers cited** → fetch them (PDFs are fully supported — fetch directly)
-- **Documentation linked** → fetch it
-- **GitHub repos mentioned** → fetch the README
-- **Related topics referenced** → search and fetch
-- **People/companies mentioned** → fetch their pages
-- **Raw data, CSVs, datasets linked** → fetch and analyze them
-- **Statistics without primary sources** → search for and fetch the original data
+Claims carry more weight when the graph shows you traced them to primary sources.
 
-**PDFs work natively.** arXiv papers, NBER working papers, conference proceedings — fetch them directly. The tool auto-detects PDFs and extracts full text. Don't skip sources because they're PDFs.
+---
 
-**Use scholarly APIs for academic topics.** When the research is academic, use APIs to find papers:
-- arXiv API: `https://export.arxiv.org/api/query?search_query=...`
-- Semantic Scholar API: `https://api.semanticscholar.org/graph/v1/paper/search?query=...`
-- CrossRef API: `https://api.crossref.org/works?query=...`
+## Step 4.5: Note triage (MANDATORY throughout)
 
-Write code to call these, get structured paper data (citations, related work, abstracts), then fetch the actual PDFs.
+Never blindly `note show` every note. Triage first.
 
-Follow links deeply — don't stop at the first page. When a source links to more detailed material, primary research, or raw data, follow those links and fetch them too.
-
-**Run analysis when needed.** If you find raw data (tables, CSVs, statistics), write and run code to compute real figures, verify claims, calculate trends, and produce original analysis. Concrete numbers from actual data beat vague summaries.
-
-Spawn more fetcher agents for these secondary sources.
-
-**Do NOT stop collecting until you are certain you have enough breadth.** After each round of fetching, ask yourself: "Are there major angles, subtopics, or perspectives I haven't covered yet?" If yes, search and fetch more. If a topic has 5 facets, you need sources on all 5 — not just the first 2 you found. Keep going until you can confidently say the collection covers the full scope of the topic.
-
-## Step 4.5: Read notes efficiently — triage by frontmatter (MANDATORY)
-
-When inspecting notes in the research base, NEVER blindly `note show` every note. Bodies can be 15,000+ words; frontmatter summaries are usually under 40. **Triage first, body-read only when earned.** This protocol applies throughout the rest of the workflow — use it in Step 4 (rabbit holes), Step 8 (cross-source comparison), and Step 9 (draft writing).
-
-### Level 1 — Frontmatter sweep (cheap, always start here)
-
-```bash
-$HPR note list -j
-```
-
-Returns one object per note with `id`, `title`, `tags`, `summary`, `word_count`, `status` — **no bodies**. Scan this to build a relevance shortlist. For many claims the summary field is enough — a well-curated note's summary already tells you what the source claims, and you cite the source URL directly without re-reading the body.
-
-### Level 2 — Frontmatter-only show (targeted)
-
-For a single note whose summary hints at deeper value, pull its full frontmatter without the body:
-
-```bash
-$HPR note show <id> --meta -j
-```
-
-Adds `source`, `parent`, `created`, `updated`, `raw_file` (if the note has a PDF). Still cheap. Decide from here whether the body is worth pulling.
-
-### Level 3 — Inline body read (only for small notes)
-
-```bash
-$HPR note show <id> -j
-```
-
-Threshold: `word_count < 2000` (~2700 tokens). Small enough to read directly. Batch several at once: `note show <id1> <id2> <id3> -j`.
-
-### Level 4 — Targeted search with body, token-capped
-
-When you need content from multiple notes at once:
-
-```bash
-$HPR search "<precise question>" --include-body --max-tokens 6000 -j
-```
-
-`--max-tokens` truncates intelligently and flags `"truncated": true` on the last fitting result. Prefer this over N separate `note show` calls.
-
-### Level 5 — Delegate heavy notes to a Sonnet subagent (MANDATORY for large notes)
-
-For any note with `word_count > 6000` (~8000 tokens, often PDFs), do NOT dump it into your own context. Spawn a Sonnet subagent with a pointed extraction prompt:
-
-> Use a fresh Sonnet subagent:
-> "Read `research/notes/<id>.md` (and its raw file at `research/raw/<id>.pdf` if the frontmatter has `raw_file` set). Extract ONLY what answers this specific question: '<your precise question>'. Return under 500 words, with direct quotes for any non-trivial claim and the source URL. If the note doesn't actually answer the question, say so and stop."
-
-The subagent reads the full 20K+ tokens internally but returns only ~500 tokens to you — roughly a 40× context savings per large note, which compounds across a session.
-
-### Level 6 — Raw PDF re-extraction (rare)
-
-If a note has `raw_file: raw/<id>.pdf` in its frontmatter AND the extracted markdown looks garbled or is missing content you need (specific figure, table, equation), read the raw PDF directly with the Read tool. Most of the time the extracted markdown is sufficient — only fall back here when it's clearly broken.
-
-### Triage thresholds (guidance, not hard rules)
-
-| word_count | Tier | Action |
+| Level | Command | When |
 |---|---|---|
-| `< 2000` | Trivial | Read inline via Level 3. Batch with siblings. |
-| `2000 – 6000` | Medium | Level 2 frontmatter first. Body only if the summary suggests high value. |
-| `> 6000` | Heavy | Level 5 Sonnet delegation. Don't read inline. |
+| 1 — List | `$HPR note list -j` | Always start here. Summaries only, no bodies. |
+| 2 — Meta | `$HPR note show <id> --meta -j` | When the summary hints at deeper value. |
+| 3 — Inline | `$HPR note show <id> -j` | word_count < 2000. Batch small notes: `note show <id1> <id2> <id3> -j` |
+| 4 — Search | `$HPR search "<q>" --include-body --max-tokens 6000 -j` | When you want content across multiple notes. |
+| 5 — Subagent | Spawn `hyperresearch-analyst` (mode=extract) | word_count > 3000, OR whenever you need one specific answer from a big source. Never dump large notes inline. |
 
-Override with reason (e.g. a single 8000-word paper is your most important primary source — read it directly, once). But defaulting to "just `note show` everything" is how sessions run out of context and reports turn shallow.
+---
 
-## Step 5: Auto-link and curate
+## Steps 5–6: Curate every source
 
-Run the auto-linker to connect related notes:
+Raw fetched notes arrive with `status=draft`, `tier=unknown`, auto-detected `content_type`, and no summary. Curation has two parallel jobs:
+
+1. **Set metadata** — tier, content_type, summary, tags, status (you do this with `$HPR note update`)
+2. **Extract relevant content** — spawn `hyperresearch-analyst` on the source so you have an extract note grounded in the research goal
+
+**Both must happen for every fetched source.** The analyst extract is what gives you the substance to write deep prose about the source later; the metadata is what lets you query and filter the corpus during drafting.
+
+### Step A: Spawn the analyst on every source
+
+For research, the analyst is the default reading mechanism — not a fallback for big sources. Even small sources (1500 words) deserve analyst treatment because the analyst's URL-scan surfaces follow-up targets for the loop.
+
+```
+For each draft source note:
+  Spawn hyperresearch-analyst with:
+    research_goal: <the user's original verbatim prompt>
+    sub_goal: "establish what this source contributes and what URLs / authors / claims warrant follow-up"
+    source_note_id: <draft note id>
+    mode: guided
+    already_covered: <running list from prior analysts>
+    already_fetched_urls: <output of `$HPR sources list -j`>
+```
+
+Spawn 3–5 in parallel (Sonnet, cheap). Each analyst reads the source, persists an extract note (`--add-tag extract --parent <source-id>`), and returns an extract + next_targets + coverage status.
+
+Collect every analyst's next_targets into TodoWrite. After each batch, fetch the top next_targets WITH `--suggested-by` so the loop iterates. **The fetch:extract ratio after curation should be at least 1:1** — every fetched source has a paired extract note. The `analyst-coverage` lint rule catches misses at Checkpoint 2.
+
+### Step B: Set metadata from the analyst's findings
+
+The analyst's return tells you the tier and content_type. After it returns:
 
 ```bash
+$HPR note update <source-id> \
+  --tier <ground_truth|institutional|practitioner|commentary> \
+  --content-type <paper|docs|article|blog|forum|dataset|policy|code|book|transcript|review> \
+  --summary "<one-line description, can borrow from the analyst's extract>" \
+  --add-tag <topic> --add-tag <subtopic> \
+  --status review \
+  -j
+```
+
+**Tier and content_type are PER-NOTE decisions.** Never apply one value to the whole batch. A fandom wiki is `docs`; a news article is `article`; a named-engineer blog post is `blog`; a reddit thread is `forum`; a GitHub README is `code`. An arxiv paper on theory is `institutional`; the same paper reporting experimental data is `ground_truth`; a conference keynote transcript is `commentary`. Read each analyst return and make the call per source.
+
+### Completion check
+
+```bash
+$HPR lint --rule uncurated -j         # zero uncurated
+$HPR lint --rule provenance -j        # zero provenance issues (--suggested-by chain exists)
+$HPR lint --rule analyst-coverage -j  # zero analyst-coverage issues
 $HPR link --auto -j
-```
-
-Check what tags exist and ensure consistency:
-
-```bash
-$HPR tags -j
-```
-
-Update any notes missing summaries (auto-curation handles most, but fix any gaps):
-
-```bash
-$HPR lint -j
-$HPR repair -j
-```
-
-## Step 6: Discover the knowledge graph
-
-Find the hub notes and key connections:
-
-```bash
 $HPR graph hubs -j
-$HPR graph backlinks <most-linked-note-id> -j
 ```
 
-## Step 7: Build the conceptual scaffold (MANDATORY — before writing)
+If any lint returns issues, curation is NOT done. Go back, run more analyst calls, fetch proposed next_targets with `--suggested-by`, and re-run the lints before Checkpoint 2.
 
-This is the single biggest lever for report quality. Reports that look like references are built from a scaffold; reports that look like Wikipedia dumps are assembled by translating notes into sections. Before a single paragraph of prose, answer these four questions.
+---
 
-**Where to put the scaffold:** keep it in your working memory, or dump it to a temp file like `/tmp/scaffold.md`. **DO NOT save it as a hyperresearch note.** The research base is for durable source material, not ephemeral pre-writing analysis. Notes are forever; scaffolds are for the next hour of writing.
+## Step 7: Build the scaffold — with the verbatim user prompt as the first section
 
-1. **What is the hard question?** One sentence — the underlying difficulty, not the surface query.
-2. **What is the naive answer?** What a reader would guess before reading any sources. This is your foil — the thing the report has to explain away.
-3. **What is the structural tension?** What makes this topic worth 10,000 words? The paradox, the constraint, the thing sources disagree on, the unsettled question.
-4. **What is the progression?** Sketch 6–12 H2 section headings in **dependency order**. Each section must build on the previous one. If the headings could be shuffled, you have a catalog, not a report.
+**Required artifact:** a note tagged `scaffold` whose FIRST section is the user's verbatim prompt.
+**Verification:** `$HPR note list --tag scaffold -j` must return ≥1 entry after this step AND the body of that note must contain the verbatim user prompt.
+**On failure:** the draft has no anchor. Return to Step 7 and write the scaffold.
 
-The final report's **opening section MUST be a framework section**, not a definition section. Section 1 establishes the hard question and the structural tension. Not "X is a Y that does Z."
+Using the **Write tool**, create `research/scaffold.md` with this exact structure:
 
-## Step 8: Cross-source comparison (MANDATORY)
+```markdown
+## User Prompt (VERBATIM — gospel)
+> [the user's entire message, copied character-for-character from the prompt.
+> This is the authoritative source. Every subsequent step re-reads this
+> section. Do not paraphrase. Do not truncate. Do not reformat.]
 
-Sources earn their citations by being compared against each other, not by being listed in parallel. Find 3–5 places where your sources actually disagree, emphasize different things, or frame the same problem differently.
+## What the user explicitly asked for
+- **Explicit deliverables:** <list — or "none">
+- **Explicit entities or items:** <list — or "none">
+- **Explicit per-item fields:** <list — or "none">
+- **Explicit structure:** <or "silent">
+- **Explicit format:** <or "silent">
+- **Explicit scope cues:** <or "silent">
+- **Explicit ordering:** <or "silent">
+
+## Primary activity and secondary flavor
+- **Primary:** <collect | synthesize | compare | forecast>
+- **Secondary (optional):** <or "none">
+- **Why:** <one sentence>
+
+## Core tension
+<what makes this question non-trivial — the paradox, disagreement, tradeoff,
+or open problem the draft has to earn its way through>
+
+## The structural plan
+<Ordered list of sections the draft will produce. Honor every explicit
+structural mandate from "What the user explicitly asked for". Where the
+prompt is silent, apply the primary modality's default structural guidance.
+For each section, name it AND describe what it will contain in one line.>
+
+## Where each source will land
+<One line per curated source-id: which heading(s) it serves and in what role
+(ground-truth evidence, institutional synthesis, dissenting voice, etc.).>
+
+## Coverage checklist (the auditor will verify this)
+<One line per explicit contract from "What the user explicitly asked for".
+The auditor at Step 11 reads this checklist and verifies each item is
+ticked off in the draft. If the user said "for each of 108 Specters provide
+techniques and fate", there must be a coverage-checklist line that will be
+checked against the draft. Do not write vague checks.>
+```
+
+Then run:
 
 ```bash
-$HPR search "<topic>" --include-body -j
+$HPR note new "Scaffold: <topic>" --tag scaffold --status draft \
+  --body-file research/scaffold.md --summary "Scaffold for <topic>" -j
 ```
 
-For each disagreement, capture a short comparison block in the same scratch file as the scaffold from Step 7 — **NOT as a hyperresearch note**. These are ephemeral analysis artifacts that will end up as prose inside the final report, not durable KB entries:
-- what each source says, with URLs
-- why they differ (data, methodology, assumptions, era, scope)
-- your position on which is more credible, with reasoning
+**The verbatim user prompt goes FIRST.** This is non-negotiable. Every checkpoint re-opens the scaffold, and re-opening the scaffold means re-reading the prompt. The prompt lives inside the document so it cannot drift out of context.
 
-These comparisons become the backbone of body sections. If every source is corroborating every other source, you didn't need many sources — search again for contrarian views, criticism, or competing frameworks.
+---
+
+## Step 8: Cross-source comparisons
+
+**Required artifact:** a note tagged `comparison` containing 3–5 explicit source-vs-source disagreements with your position on each.
+**Verification:** `$HPR note list --tag comparison -j` must return ≥1 entry after this step.
+**On failure:** the thesis / recommendation / forecast has no stress test. "I did it in my head" is not acceptable.
+
+Find 3–5 places where sources disagree. Read both at Level 3+ before comparing.
+
+Using the **Write tool**, create `research/comparisons.md`:
+
+```markdown
+## Disagreement 1: <what axis are they disagreeing about>
+- Source A ([URL]): <claim/reading> because <reasoning/evidence>
+- Source B ([URL]): <different claim> because <different reasoning>
+- Why they differ: <theoretical framework? different data? different time window? different scope?>
+- My position: <which is more credible and why — take a side, with the evidence that tips the balance>
+```
+
+Then run:
+
+```bash
+$HPR note new "Comparisons: <topic>" --tag comparison --status draft \
+  --body-file research/comparisons.md --summary "Source comparison for <topic>" -j
+```
+
+---
 
 ## Step 9: Write the draft
 
-**First, pull up your classification from Step 0.5.** The parameter block for your primary type sets target length, H2 count, opening shape, and analytical mode. The hard constraints below are Type 0 defaults — they apply EXCEPT where your type's block overrides them. Notable overrides:
-- **Type 4 Humanities** targets 6–10 longer H2s (800–1500 words each), not 12–20.
-- **Type 2 Market** wants one section per vendor *cluster*, not per individual vendor.
-- **Type 5 Comparative** requires a mandatory comparison matrix in the body.
-- **Type 6 Emerging** requires a "What we don't know yet" section.
+**Before writing anything:** re-open `research/scaffold.md`. Re-read the verbatim user prompt. Re-read the "What the user explicitly asked for" extraction. Re-read the coverage checklist. This is mandatory — every draft session must begin with re-encountering the prompt.
 
-Now write the report. These are hard constraints (under Type 0; type-specific overrides apply where listed above):
+Then read your modality file's substance rules. The modality file tells you HOW to write: interpretation density (synthesize), enumerative completeness (collect), proportionate depth + recommendation (compare), probability language + time horizon (forecast).
 
-- **Target 400–600 words per H2 section.** Sections under 200 words get merged. Sections over 800 get split — only if both halves stay above 300. (Type 4 Humanities: 800–1500.)
-- **Aim for 12–20 H2 headings on a 10K-word report; 8–15 on a 5K-word report.** Above 25 is fragmentation — merge. (Type 4 Humanities: 6–10.)
-- **Never write one section per source or one section per named entity.** A single H2 section weaves 3–8 sources together. A character, vendor, or paper does not earn its own section unless it has >400 words of real analysis attached.
-- **Every body section ends with an analytical beat** — a 1–2 sentence "so what does this tell us" that integrates across the sources just cited. The Opinionated Synthesis at the end is NOT supposed to carry the synthesis load alone.
-- **Open with the framework from Step 7, not a definition.** Section 1 = hard question + naive answer + structural tension.
-- **Cite inline with parenthetical URLs.** Every non-trivial claim needs one. Prefer primary sources.
-- **Comparison tables over fact tables.** A good table contrasts cases on a common axis. A bad table dumps attributes of one entity.
-- **Word count targets.** Simple factual: 3,000–5,000. Complex/technical: 6,000–9,000. PhD-level: 9,000–12,000. Missing these is usually a signal that the scaffold from Step 7 is wrong — go back and fix the scaffold before writing more prose.
+**Write `research/notes/final_report.md`** as a normal markdown file (no frontmatter needed for the draft — final save happens at Step 13).
 
-## Step 10: Gap analysis (MANDATORY)
+### Shared writing constraints (apply to every activity)
 
-After writing your draft, stop and compare it against the original query. Re-read the user's request word by word:
-- What specific questions did they ask that I haven't fully answered?
-- What subtopics or angles did I miss entirely?
-- Where did I make claims without strong enough evidence?
-- What would an expert in this field say is missing?
+- **The opening must establish the core tension.** What makes this question non-trivial? What paradox, disagreement, tradeoff, or open problem is the draft earning its way through? If the user requested a specific opening shape (definitions, executive summary, narrative hook), honor that shape — then make it do tension-framing work.
+- **Every body section must earn its analytical beat.** A section that just describes facts without making an interpretive / comparative / forward move is a catalog entry, not a research contribution. Each section ends with a so-what, a comparison, a tension, or a forward beat.
+- **Sources in tension at least twice in the body.** Find two places where your sources disagree and walk the reader through the disagreement, naming both positions and explaining which is more defensible. Synthesis alone does not make up for this — the body itself must engage dissent.
+- **Every claim has a citation.** Inline parenthetical URL, or `[[note-id]]` if you want the reader to trace it in the vault.
+- **Tier weighting.** Anchor substantive claims in `ground_truth` sources. Use `institutional` for positioning. Use `practitioner` for reality checks. Use `commentary` only to characterize reception, never to establish a load-bearing claim.
+- **No padding to hit a length.** There is no length target. If your substance fits in 3,000 words, write 3,000 words. If it needs 12,000, write 12,000. A draft should be as long as the content demands.
 
-Launch a new round of research to fill every gap — web search, fetch, follow links, spawn fetcher subagents in parallel. Add the new material to your draft.
+### Activity-specific substance rules
 
-## Step 11: Adversarial audit (MANDATORY — do this twice)
+Open your modality file and read its Step 9 section. Its substance rules layer on top of the shared constraints above — they do not replace them.
 
-After the gap-filling round, launch two subagents in parallel to audit the revised draft:
+### Secondary flavor layering (MANDATORY when your scaffold declared a secondary)
 
-**Agent 1 — Comprehensiveness auditor:**
+If your Step 1 classification declared a secondary flavor, your draft must satisfy BOTH modalities' substance rules — not just the primary's. Read the **secondary modality's Step 9 substance rules AND its conformance checks** before you start writing.
+
+Conflict resolution:
+- **Primary wins on structure.** Section shape, entity-vs-thematic sequencing, comparison-matrix presence, scaffold skeleton — all determined by the primary modality.
+- **Secondary wins on substance within sections.** Per-paragraph density rules, tension requirements, interpretation/enumeration discipline — these layer on top of the primary's structure.
+
+Example (Q91-style: `primary=collect`, `secondary=synthesize`):
+- Collect (primary) forces per-character coverage across every entity category in the prompt. The structure is entity-based.
+- Synthesize (secondary) forces every paragraph to fuse fact with interpretive claim AND at least two body sections to put sources in tension.
+- The draft has entity-named sections (primary structure) where every paragraph inside makes an interpretive claim about what that entity means (secondary substance).
+
+The auditor applies BOTH check lists at Step 11. Secondary-flavor violations are **not waivable** — they are CRITICAL findings that block synthesis save via the `audit-gate` lint rule. If a prompt is genuinely 50/50 across two activities, plan to satisfy both; do not silently drop the secondary.
+
+---
+
+## Step 10: Gap analysis + adversarial search
+
+After the first draft, run adversarial searches specific to your activity — the modality file names the queries. Ask yourself:
+
+- Did you engage with the strongest counter-position?
+- Is every item in the scaffold's coverage checklist actually ticked off in the draft?
+- Are there tiers you're missing (all commentary, no ground_truth)?
+- Is there a named voice you should be citing that isn't in the vault yet?
+
+Fetch what's missing. Update the draft.
+
+---
+
+## Step 11: Adversarial audit — spawn `hyperresearch-auditor` twice
+
+**Required artifact:** text output from both `hyperresearch-auditor` runs in your context, plus every identified violation applied to the draft.
+**Verification:** in writing, list each violation the auditors raised and whether it has been fixed or explicitly rejected.
+**On failure:** an unapplied audit is equivalent to no audit. Task has FAILED at Checkpoint 4.
+
+**Spawn `hyperresearch-auditor` twice — once per mode. Run them SEQUENTIALLY, comprehensiveness first then conformance.** The auditor is a registered Claude Code agent (`.claude/agents/hyperresearch-auditor.md`) running on Opus. Both runs MUST receive the user's original research query **verbatim** — the same prompt you pasted into the scaffold.
+
+Run comprehensiveness first so its findings land in `research/audit_findings.json` without a write race, then run conformance which reads the file and appends its own entry.
+
 ```
-Read this report and search the research base ($HPR search, $HPR note show) to find gaps.
-What subtopics, angles, data points, or counterarguments are missing? What claims lack
-citations? What sections are shallow? Compare against the original query and be ruthless —
-list every gap you find.
+First spawn (wait for completion before the second):
+  research_query: <paste the user's verbatim prompt from scaffold §1>
+  modality: <collect | synthesize | compare | forecast>
+  mode: comprehensiveness
+  final_report_path: research/notes/final_report.md
+  scaffold_note_id: <scaffold note id>
+  comparison_note_id: <comparison note id>
+
+Second spawn (only AFTER the first has returned and written its entry):
+  research_query: <paste the user's verbatim prompt from scaffold §1>
+  modality: <collect | synthesize | compare | forecast>
+  mode: conformance
+  final_report_path: research/notes/final_report.md
+  scaffold_note_id: <scaffold note id>
+  comparison_note_id: <comparison note id>
 ```
 
-**Agent 2 — Logic and structure auditor:**
-```
-Read this report as a domain expert. The report should declare its request type
-(Step 0.5 classification) and follow the matching parameter block. Check specifically:
-  (1) Does section 1 establish a framework — hard question, naive answer, structural
-      tension — or does it just define terms?
-  (2) Are sections in dependency order? Does each section build on the previous one, or
-      could they be shuffled without loss?
-  (3) Are there sections under 200 words that should be merged into siblings?
-      (Type 4 Humanities: <400 is the floor, not 200.)
-  (4) Count H2 headings. Fragmentation thresholds vary by type: Type 0 General is >25 on
-      a <12K-word report; Type 4 Humanities is >12; Type 2 Market is >15.
-  (5) Does each body section end with an analytical beat, or does it just stop?
-  (6) Are sources compared against each other anywhere, or only listed in parallel?
-  (7) Does the argument flow logically — leaps, unsupported claims, contradictions?
-  (8) Does the report match its declared request type? If Type 4 Humanities, are sections
-      thematic rather than entity-catalog? If Type 5 Comparative, is there a mandatory
-      comparison matrix? If Type 6 Emerging, is there a "What we don't know yet" section?
-      If Type 2 Market, is there a position on who is winning? Flag every type violation.
-List every weakness with specific section names and direct quotes.
-```
+After both have returned, verify `research/audit_findings.json` has TWO new entries (one per mode) before proceeding. If only one mode's entry is present, re-spawn the missing mode — the `audit-gate` lint rule will fail at Step 13 if either is missing.
 
-Pass your full draft report text to both agents.
+The auditor reads your modality file's "Conformance checks" section, applies each check, persists its findings to `research/audit_findings.json`, and returns a text summary with `pass` / `needs_fixes` / `failed` status. Apply every CRITICAL finding before saving the synthesis, and mark each fixed finding's `fixed_at` field in the JSON file as you go. The auditor also reads the scaffold — so it re-encounters the verbatim prompt — and verifies the draft honors the scaffold's coverage checklist.
 
-**After each audit round:**
-1. Read both agents' feedback
-2. If they found missing topics or weak arguments — do another round of web search + fetching
-3. If the structure auditor flagged fragmentation, short sections, or a missing framework — **consolidate and rewrite, don't just patch.** Merging five 100-word sections into one 500-word section is a rewrite, not an edit. This is where catalog-style drafts become argument-style drafts.
-4. Rewrite the report with new sources and structural fixes
-5. Run the audit again (second loop) on the revised report
+---
 
-**Do at least one audit loop. Do two if the first found significant gaps.** Only finalize after auditors have no major complaints.
+## Step 12: Opinionated synthesis
 
-**While audit agents are running, don't idle.** Use the wait time to:
-- Improve weak or missing summaries on notes (`$HPR note update <id> --summary "..." -j`)
-- Add more specific tags to under-tagged notes (`$HPR note update <id> --add-tag <tag> -j`)
-- Add `[[wiki-links]]` between related notes
-- Run `$HPR lint -j` and fix issues
-- Read notes you haven't reviewed yet for links worth following
-
-## Step 12: Opinionated synthesis (MANDATORY — end of report)
-
-A comprehensive catalog of facts is not a report. Before finalizing, you **MUST** append a section titled **`## Opinionated Synthesis`** at the very end of the report. This is where you stop reciting what sources said and start **reasoning across them**.
-
-This section **complements — it does not replace** — the per-section analytical beats from Step 9. If all the analysis is dumped in this appendix and the body sections are purely descriptive, the report is still a catalog with a synthesis bolted onto the end. Both are required.
-
-**Your Opinionated Synthesis section MUST include:**
-
-1. **Comparative analysis across categories.** Don't just describe each group or concept in isolation — compare them. What do the groups have in common? Where do they differ? What patterns emerge when you look at them side by side? Build at least one comparison table if the topic supports it.
-
-2. **Thematic threads and progression.** What themes cut across the whole topic? What's the narrative arc? How do things evolve over time, across versions, across authors, across schools of thought? Identify the throughlines.
-
-3. **Your reasoned position.** Take a defensible stance. What's the most important finding? What's over-hyped? What's underrated? What do you expect to change in the next 2–5 years? Label it clearly as your own analysis, grounded in the sources you fetched.
-
-4. **Open questions and limitations.** What did the sources NOT answer? What would an expert say is still unclear? Where is the research thin? Name the gaps explicitly.
-
-5. **Concluding thoughts.** One tight paragraph that ties everything back to the user's original question. What's the takeaway they should remember?
-
-**Structure of the synthesis section (use these subheadings exactly):**
+Append this to the end of the draft:
 
 ```markdown
 ## Opinionated Synthesis
 
-### Comparative Analysis
-<cross-cutting comparisons — tables where useful>
+### <Activity-specific header — see modality file>
+<the cross-cutting picture the modality demands: thematic threads for
+synthesize, comparison matrix for compare, position-with-horizon for
+forecast, coverage summary for collect>
 
 ### Thematic Threads
-<patterns, progressions, throughlines across the topic>
+<patterns across the body sections that the per-section analysis couldn't
+surface — what the whole corpus is saying that no single source said>
 
 ### My Reasoned Position
-<your defensible stance, clearly labeled as analysis>
+<your defensible stance, explicitly labeled. Synthesize demands a thesis;
+compare demands a recommendation; forecast demands a prediction with
+probability language and a time horizon; collect demands a "what this whole
+set amounts to" claim.>
 
 ### Open Questions
-<gaps in the research, what the sources didn't answer>
+<what the sources didn't settle, what data is unavailable, what would
+change your position>
 
 ### Concluding Thoughts
-<one tight paragraph, answers the original question>
+<one tight paragraph: the single most important thing a reader should
+take away — and why>
 ```
 
-**Do NOT skip this section.** A report without an Opinionated Synthesis is incomplete. Even 9,000 words of carefully cataloged facts is just reference material without it. The synthesis is what separates a research report from a Wikipedia dump.
+---
 
-## Step 13: Save the final report
+## Steps 13–14: Save and present
 
-Save the final reviewed report as a synthesis note:
+**Before saving the synthesis**, run the audit-gate lint to confirm the audit loop is closed. This is a hard gate — the synthesis cannot be saved until it returns zero error-severity issues:
 
 ```bash
-cat > /tmp/synthesis.md << 'SYNTHESIS'
-# <Topic> — Research Synthesis
+$HPR lint --rule audit-gate -j
+```
 
-## Key Findings
-<your synthesis here>
+The `audit-gate` rule checks three conditions against `research/audit_findings.json`:
 
+1. **Both audit modes must have appended a run.** If the file has a comprehensiveness run but no conformance run (or vice versa), the gate fails with a missing-mode error — spawn the missing auditor mode and retry.
+2. **No unresolved CRITICAL findings in the most recent conformance run.** Every CRITICAL must have a non-null `fixed_at` timestamp. Walk the unresolved list, apply the fix to `research/notes/final_report.md`, and mark `fixed_at: <current ISO timestamp>` on the finding in the JSON file. If a finding cannot be fixed (e.g. the auditor misread the draft), resolve it by marking `fixed_at` with a `notes` field explaining why the rejection is safe — but that is a last resort, not a bypass.
+3. **IMPORTANT findings surface as `info` severity** (advisory, does not block save). They appear in the lint output so you see them before committing. You are strongly encouraged to patch them if they name real gaps — they often do. Mark each as `fixed_at` in the JSON once patched.
+
+After applying fixes:
+- If you patched the draft, re-spawn the conformance auditor (which will append a fresh run to the findings file) and re-run the lint.
+- If `audit-gate` returns zero error-severity issues — proceed to save.
+- If it still fails, diagnose which specific finding is blocking and address it. **Do NOT bypass the gate by editing `audit_findings.json` to clear findings without patching the draft first.**
+
+This is how the audit loop actually closes: findings are persisted → fixes are applied → `fixed_at` is set → the lint passes → the synthesis saves. Each step leaves an artifact on disk.
+
+Using the **Write tool**, create `research/synthesis.md`:
+
+```markdown
+# <Topic> — Synthesis
+## Position
+<your thesis / recommendation / forecast / coverage summary>
 ## Sources
-<wiki-links to all source notes: [[note-id-1]], [[note-id-2]], etc.>
-
+<[[note-id-1]], [[note-id-2]], ...>
 ## Open Questions
-<what wasn't answered, what needs more research>
-SYNTHESIS
-
-$HPR note new "Synthesis: <topic>" --tag <topic> --tag synthesis --type moc --status review --body-file /tmp/synthesis.md --summary "<one-line summary of findings>" -j
+<unresolved>
 ```
 
-## Step 14: Present to user
+Then run:
 
-Present your findings with:
-
-1. **Executive summary** — 2-3 sentence answer to their question
-2. **Key findings table** — the most important discoveries
-3. **Sources collected** — how many notes, from which domains
-4. **Hub notes** — the most-referenced/important notes in the graph
-5. **Open questions** — what you didn't find or what needs more research
-6. **How to explore** — tell them they can ask follow-up questions and you'll search the KB
-
-Example closing:
-```
-Research complete. 15 sources collected on "<topic>":
-- 3 primary papers, 5 technical blogs, 4 documentation pages, 3 news articles
-- Hub notes: [[key-note-1]], [[key-note-2]]
-- All sources are saved and searchable across sessions.
-
-Ask me anything about this topic — I'll search the research base first.
+```bash
+$HPR note new "Synthesis: <topic>" --tag <topic> --tag synthesis --type moc \
+  --status review --body-file research/synthesis.md \
+  --summary "<one-line position>" -j
 ```
 
-## Important rules
+Present to the user: your position in 2–3 sentences, the key structural beats, sources collected, and what would change your position.
 
-- **NEVER use WebFetch for source pages.** Always use `$HPR fetch` or the fetcher subagent.
-- **Over-collect, then prune.** Fetch aggressively. Deprecate irrelevant notes after synthesis.
-- **Save raw content.** Don't rewrite or summarize sources before saving. The full text is the value.
-- **Follow links.** A blog post about a paper is not the paper. Fetch the paper.
-- **Save your synthesis.** Every research session should produce a synthesis note that future agents can find.
+---
+
+## Process review checkpoints
+
+Each checkpoint is a STOP point. Run the commands, state results in writing, decide whether the task has failed.
+
+### Checkpoint 1 — after Step 3 (post-fetch)
+
+**Purpose:** verify the corpus has enough voice diversity before reading it.
+
+```bash
+$HPR note list --status draft -j | python -c "import sys,json; d=json.load(sys.stdin)['data']; print(f'draft notes: {len(d)}')"
+$HPR sources list -j | python -c "
+import sys, json
+from collections import Counter
+from urllib.parse import urlparse
+d = json.load(sys.stdin)['data']
+sources = d if isinstance(d, list) else d.get('sources', [])
+total = len(sources)
+domains = Counter(urlparse(s['url']).netloc.replace('www.','') for s in sources if s.get('url'))
+print(f'total sources: {total}, unique domains: {len(domains)}')
+for dom, count in domains.most_common(10):
+    pct = count / max(total, 1) * 100
+    flag = ' <-- OVER 30% (concentrated)' if pct > 30 else ''
+    print(f'  {count:>3}  ({pct:>5.1f}%)  {dom}{flag}')
+"
+```
+
+**Pass conditions:**
+- [ ] At least one note fetched from each mandatory adversarial search
+- [ ] No single domain represents >30% of fetched sources (voice diversity)
+- [ ] At least 5 unique non-reference voices (critical essays, named-author blog posts, peer-reviewed papers — NOT listicles or reference wikis)
+
+**On failure:** run additional searches with diversified queries, vary the source types, seek named voices. Return to Step 2.
+
+### Checkpoint 2 — after Steps 5–6 (post-curate)
+
+**Purpose:** verify every source has been analyzed AND classified.
+
+```bash
+$HPR lint --rule uncurated -j
+$HPR lint --rule provenance -j
+$HPR lint --rule analyst-coverage -j
+$HPR note list --all -j | python -c "import sys,json; from collections import Counter; notes=json.load(sys.stdin)['data']; t=Counter(n.get('tier') for n in notes if n.get('status')!='draft'); ct=Counter(n.get('content_type') for n in notes if n.get('status')!='draft'); print(f'tiers: {dict(t)}'); print(f'content_types: {dict(ct)}')"
+```
+
+**Pass conditions:**
+- [ ] Zero `uncurated` issues
+- [ ] Zero `provenance` **errors** — the rule itself computes the non-seed ratio and errors when under 30% on a corpus >10, so if this lint returns zero errors the guided loop fired adequately. Read its output carefully; its message tells you `non_seeds / total` directly.
+- [ ] Zero `analyst-coverage` issues (at least 33% of fetched sources have a paired extract note)
+- [ ] Tier and content_type distributions are nuanced (not one dominant value)
+- [ ] At least two tiers represented
+- [ ] At least three content_types represented
+
+**On failure:** re-classify per-note based on each analyst's return; spawn analysts on skipped sources; **run the guided reading loop**: spawn `hyperresearch-analyst` on existing sources, collect their `next_targets`, and fetch the top 3-5 WITH `--suggested-by <source-note-id>`. You cannot proceed to Step 7 (scaffold) until the guided loop has fired at least once — the provenance chain is a load-bearing invariant.
+
+**Specifically when `provenance` errors:** the rule message will say something like *"Only 3/19 source notes (16%) have breadcrumbs — the guided reading loop did not fire"*. Read that number literally. If it's below 30%, you MUST return to Step 4 and run the guided loop: spawn an analyst on each existing source, collect `next_targets`, fetch each target with `--suggested-by <source-note-id> --suggested-by-reason "<why>"`, then re-run Checkpoint 2. Skipping this means the draft rests on seed fetches alone and the bouncing-loop-discovered critical voices never made it into the corpus.
+
+### Checkpoint 3 — BEFORE Step 9 (pre-draft gate — CRITICAL)
+
+**Purpose:** this is the gate that protects the draft from being written on a broken foundation.
+
+```bash
+$HPR note list --tag scaffold -j | python -c "import sys,json; d=json.load(sys.stdin)['data']; print(f'scaffold notes: {len(d)}')"
+$HPR note list --tag comparison -j | python -c "import sys,json; d=json.load(sys.stdin)['data']; print(f'comparison notes: {len(d)}')"
+$HPR note list --tag extract -j | python -c "import sys,json; d=json.load(sys.stdin)['data']; print(f'extract notes: {len(d)}')"
+$HPR lint --rule scaffold-prompt -j
+$HPR lint --rule uncurated -j
+$HPR lint --rule provenance -j
+$HPR lint --rule analyst-coverage -j
+$HPR lint --rule workflow -j
+```
+
+**Pass conditions:**
+- [ ] Scaffold note count ≥ 1
+- [ ] Zero `scaffold-prompt` issues — the scaffold body MUST contain the verbatim user prompt as its first section. This is machine-checked; the gospel rule is non-negotiable.
+- [ ] Comparison note count ≥ 1
+- [ ] Extract note count ≥ 30% of fetched source count
+- [ ] Zero `uncurated`, `provenance`, `analyst-coverage`, `workflow` issues
+
+**On failure:** you CANNOT write the draft. Return to the step that produces the missing artifact. If `scaffold-prompt` failed, return to Step 7 and re-write the scaffold with the user's verbatim prompt as its first section — do not fudge it.
+
+### Checkpoint 4 — after Step 11 (post-audit)
+
+**Purpose:** verify the audit fired and its findings were applied.
+
+**Pass conditions:**
+- [ ] `hyperresearch-auditor` was spawned twice (comprehensiveness + conformance) and both returned
+- [ ] Every violation flagged has been fixed in `research/notes/final_report.md` OR explicitly rejected in writing with a reason
+- [ ] If the conformance auditor flagged missing scaffold / comparison / extract notes, you returned to the relevant checkpoint and fixed it
+
+**On failure:** spawn the auditor (or re-spawn) and apply the findings. Do not save the synthesis note until this checkpoint passes.
+
+---
+
+## CLI path
+
+Find the `hyperresearch` executable from CLAUDE.md ("CLI path:" line) and store it:
+
+```bash
+HPR="<path from CLAUDE.md>"
+```

--- a/src/hyperresearch/skills/research.md
+++ b/src/hyperresearch/skills/research.md
@@ -220,6 +220,48 @@ Each iteration is a research director: the analyst reads one source, proposes wh
 
 Spawn `hyperresearch-fetcher` on ONLY those 3–5. Do NOT batch-fetch 20 URLs upfront — half get wasted on sources the loop would tell you to skip.
 
+#### When a fetch fails — try harder before giving up
+
+PDF hosts on academic faculty pages, ResearchGate, SSRN, and publisher sites are notoriously flaky (403, paywall walls, junk content, login walls). When a fetch returns `error`, `JUNK_CONTENT`, `AUTH_REQUIRED`, or any non-success status, **do NOT silently move on if the source is high-priority.** A high-priority source is one that:
+
+- Is the seminal paper an analyst specifically named as a `next_target`
+- Is the canonical source for the question (e.g., the original Maskin-Riley paper for an asymmetric-auctions query)
+- Is the only voice from a missing tier (e.g., the only practitioner perspective in a corpus of academic papers)
+
+For high-priority failures, work through this fallback chain in order — stop as soon as one succeeds:
+
+1. **Try alternative URLs for the same paper:**
+   - arXiv preprint version (`arxiv.org/abs/<id>` or `arxiv.org/pdf/<id>`)
+   - Author's personal page (search `"<author surname> <paper title> filetype:pdf"`)
+   - Department / institutional repository (search `"<paper title> site:<institution>.edu"`)
+   - SSRN, RePEc, NBER, OpenAlex, Semantic Scholar mirror
+   - Google Scholar's "All N versions" link
+2. **Try the visible-browser flag** on the original URL: `$HPR fetch "<url>" --visible ...`. The `--visible` flag runs the browser non-headless; many sites that block headless requests succeed when the browser is visible. Cost: ~5-10s slower per fetch.
+3. **Try the user's authenticated profile** if one is configured: `$HPR fetch "<url>" --profile research ...`. Login profiles bypass paywalls on sites the user has logged into. If no profile is configured, the user can create one via `hyperresearch setup`.
+4. **As a last resort**, search for a **summary or review** of the paper that captures its key claims (e.g., a textbook chapter that summarizes the result). Note this in the source's frontmatter `summary:` field as `(via summary, original PDF unavailable)`.
+5. **If all four fail and the source is genuinely irreplaceable**, surface the failure to the user — don't ship a draft that depends on a source you couldn't read.
+
+Document failures in the scaffold's "Where each source will land" section. The auditor will see the explicit gap and can flag whether the draft works around it correctly.
+
+**Low-priority fetch failures** (a peripheral source the analyst flagged with low confidence) — skip and move on. Don't waste five fallback attempts on a tangential source.
+
+#### Mandatory `--suggested-by` discipline at fetch time
+
+Every `$HPR fetch` call from Phase 2 onward MUST pass `--suggested-by <source-note-id>` AT FETCH TIME. Do NOT batch-fetch a list of next_targets first and then backfill breadcrumbs later — that produces disconnected provenance graphs that the rooted-tree lint catches as errors at Checkpoint 2.
+
+The pattern is: analyst returns `next_targets[]` with each target's `proposed_by` source id → main agent fetches each target with the corresponding `--suggested-by` flag in the same call. One subprocess per target, with the breadcrumb baked in.
+
+```bash
+# CORRECT — breadcrumb at fetch time
+$HPR fetch "<url>" --suggested-by <source-id> --suggested-by-reason "<why>" -j
+
+# WRONG — fetch first, append breadcrumb later
+$HPR fetch "<url>" -j                  # creates seed-style note
+$HPR note edit <new-id> ...            # tries to graft a breadcrumb after the fact
+```
+
+Backfilling is supported (the fetch CLI is idempotent on re-call with `--suggested-by`), but the resulting provenance graph has disconnected components — the new note's breadcrumb points at the suggester, but if the suggester was itself a seed, the chain looks artificial. The rooted-tree provenance lint flags this and the audit-gate blocks save until you connect the islands.
+
 **Phase 2 — Guided reading iterations.** For each fresh note, spawn the **`hyperresearch-analyst`** agent (Sonnet, registered at `.claude/agents/hyperresearch-analyst.md`) with `mode=guided`:
 
 ```
@@ -640,11 +682,12 @@ for dom, count in domains.most_common(10):
 ```
 
 **Pass conditions:**
-- [ ] At least one note fetched from each mandatory adversarial search
+- [ ] At least one note fetched from each mandatory adversarial search in your modality file
+- [ ] **At least one source explicitly dissents from / criticizes the dominant view.** "Dominant view" is what the bulk of your corpus implicitly endorses; the dissenting source must contradict it directly (not just complicate it). State the dominant view in writing and identify which source is the dissent. If you cannot identify one, you have NOT satisfied the adversarial round — go fetch one before proceeding.
 - [ ] No single domain represents >30% of fetched sources (voice diversity)
 - [ ] At least 5 unique non-reference voices (critical essays, named-author blog posts, peer-reviewed papers — NOT listicles or reference wikis)
 
-**On failure:** run additional searches with diversified queries, vary the source types, seek named voices. Return to Step 2.
+**On failure:** run additional searches with diversified queries, vary the source types, seek named voices. For the dissent gap specifically: search for the named opponent of the dominant figure ("Roubini on inflation" rather than "inflation criticism"), look for retractions/withdrawals, look for "we tried X and switched to Y" postmortems. Return to Step 2.
 
 ### Checkpoint 2 — after Steps 5–6 (post-curate)
 

--- a/src/hyperresearch/web/crawl4ai_provider.py
+++ b/src/hyperresearch/web/crawl4ai_provider.py
@@ -33,7 +33,7 @@ if sys.platform == "win32":
 
 def _is_pdf_url(url: str) -> bool:
     """Check if URL likely points to a PDF."""
-    from urllib.parse import urlparse, parse_qs
+    from urllib.parse import urlparse
 
     parsed = urlparse(url.lower())
     path = parsed.path
@@ -44,9 +44,7 @@ def _is_pdf_url(url: str) -> bool:
     if "/pdf/" in path or "/pdfs/" in path:
         return True
     # arXiv PDF links
-    if "arxiv.org" in parsed.netloc and ("/pdf/" in path or "/abs/" in path):
-        return True
-    return False
+    return "arxiv.org" in parsed.netloc and ("/pdf/" in path or "/abs/" in path)
 
 
 def _looks_like_binary(text: str) -> bool:
@@ -58,10 +56,10 @@ def _looks_like_binary(text: str) -> bool:
     pdf_markers = ("endstream", "endobj", "/Filter", "/FlateDecode", "stream\nx", "%PDF-")
     if any(m in sample for m in pdf_markers):
         return True
-    # High ratio of actual binary/control chars — do NOT flag ord(c) > 127, as that would
+    # High ratio of actual binary/control chars - do NOT flag ord(c) > 127, as that would
     # falsely reject valid CJK, Arabic, Cyrillic, and other non-ASCII text.
     # Only flag: true control chars (< 0x20, excluding normal whitespace), the Unicode
-    # replacement character (U+FFFD from bad decoding), and C1 controls (0x80–0x9F).
+    # replacement character (U+FFFD from bad decoding), and C1 controls (0x80-0x9F).
     def _is_garbage(c: str) -> bool:
         o = ord(c)
         return (o < 0x20 and c not in '\t\n\r\f\v') or c == '\ufffd' or (0x80 <= o <= 0x9F)

--- a/src/hyperresearch/web/crawl4ai_provider.py
+++ b/src/hyperresearch/web/crawl4ai_provider.py
@@ -58,9 +58,15 @@ def _looks_like_binary(text: str) -> bool:
     pdf_markers = ("endstream", "endobj", "/Filter", "/FlateDecode", "stream\nx", "%PDF-")
     if any(m in sample for m in pdf_markers):
         return True
-    # High ratio of non-printable or replacement chars
-    non_printable = sum(1 for c in sample if ord(c) > 127 or c in '\x00\x01\x02\x03\x04\x05')
-    return non_printable > len(sample) * 0.15
+    # High ratio of actual binary/control chars — do NOT flag ord(c) > 127, as that would
+    # falsely reject valid CJK, Arabic, Cyrillic, and other non-ASCII text.
+    # Only flag: true control chars (< 0x20, excluding normal whitespace), the Unicode
+    # replacement character (U+FFFD from bad decoding), and C1 controls (0x80–0x9F).
+    def _is_garbage(c: str) -> bool:
+        o = ord(c)
+        return (o < 0x20 and c not in '\t\n\r\f\v') or c == '\ufffd' or (0x80 <= o <= 0x9F)
+    garbage = sum(1 for c in sample if _is_garbage(c))
+    return garbage > len(sample) * 0.05
 
 
 def _fetch_pdf(url: str) -> WebResult | None:

--- a/tests/test_cli/test_lint.py
+++ b/tests/test_cli/test_lint.py
@@ -1,0 +1,517 @@
+"""Tests for lint rules — especially the gospel-enforcing scaffold-prompt rule."""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from hyperresearch.cli.lint import app as lint_app
+from hyperresearch.core.note import write_note
+
+
+def _run_lint(vault, rule: str | None = None) -> tuple[int, str]:
+    """Invoke `hyperresearch lint` CLI against a vault. Returns (exit_code, stdout)."""
+    import os
+
+    runner = CliRunner()
+    prev_cwd = os.getcwd()
+    try:
+        os.chdir(vault.root)
+        args = ["--json"]
+        if rule:
+            args = ["--rule", rule, "--json"]
+        result = runner.invoke(lint_app, args, catch_exceptions=False)
+        return result.exit_code, result.output
+    finally:
+        os.chdir(prev_cwd)
+
+
+def _write_scaffold(vault, body: str, note_id: str = "scaffold-test"):
+    write_note(
+        vault.notes_dir,
+        "Scaffold: Test",
+        body=body,
+        tags=["scaffold"],
+        note_id=note_id,
+    )
+    vault.auto_sync()
+
+
+def test_scaffold_prompt_passes_with_verbatim_prompt(tmp_vault):
+    _write_scaffold(
+        tmp_vault,
+        body=(
+            "## User Prompt (VERBATIM — gospel)\n"
+            "> I would like a detailed analysis of the Saint Seiya franchise and its armor classes. "
+            "For each significant character please describe techniques and fate.\n\n"
+            "## What the user explicitly asked for\n"
+            "- Entity enumeration\n"
+        ),
+    )
+    code, out = _run_lint(tmp_vault, rule="scaffold-prompt")
+    assert code == 0
+    # Output should contain no scaffold-prompt issues
+    import json
+    data = json.loads(out)
+    issues = data.get("data", {}).get("issues", [])
+    scaffold_issues = [i for i in issues if i.get("rule") == "scaffold-prompt"]
+    assert scaffold_issues == []
+
+
+def test_scaffold_prompt_fails_when_header_missing(tmp_vault):
+    _write_scaffold(
+        tmp_vault,
+        body=(
+            "## Thesis\n"
+            "Saint Seiya's armor hierarchy encodes a theology of sacrifice.\n\n"
+            "## Heading progression\n"
+            "1. Cosmology\n"
+        ),
+    )
+    code, out = _run_lint(tmp_vault, rule="scaffold-prompt")
+    import json
+    data = json.loads(out)
+    issues = data.get("data", {}).get("issues", [])
+    scaffold_issues = [i for i in issues if i.get("rule") == "scaffold-prompt"]
+    assert len(scaffold_issues) == 1
+    assert scaffold_issues[0]["severity"] == "error"
+    assert "verbatim" in scaffold_issues[0]["message"].lower()
+
+
+def test_scaffold_prompt_warns_when_quote_too_short(tmp_vault):
+    _write_scaffold(
+        tmp_vault,
+        body=(
+            "## User Prompt (VERBATIM — gospel)\n"
+            "> hi\n\n"
+            "## What the user explicitly asked for\n"
+            "- thing\n"
+        ),
+    )
+    code, out = _run_lint(tmp_vault, rule="scaffold-prompt")
+    import json
+    data = json.loads(out)
+    issues = data.get("data", {}).get("issues", [])
+    scaffold_issues = [i for i in issues if i.get("rule") == "scaffold-prompt"]
+    assert len(scaffold_issues) == 1
+    assert scaffold_issues[0]["severity"] == "warning"
+
+
+def test_scaffold_prompt_no_scaffold_notes_is_noop(tmp_vault):
+    # A vault with no scaffold-tagged notes should produce no issues for this rule.
+    code, out = _run_lint(tmp_vault, rule="scaffold-prompt")
+    assert code == 0
+    import json
+    data = json.loads(out)
+    issues = data.get("data", {}).get("issues", [])
+    scaffold_issues = [i for i in issues if i.get("rule") == "scaffold-prompt"]
+    assert scaffold_issues == []
+
+
+def _write_source(vault, title: str, note_id: str, body: str = "Source content."):
+    write_note(
+        vault.notes_dir,
+        title,
+        body=body,
+        note_id=note_id,
+        source=f"https://example.com/{note_id}",
+        tier="institutional",
+        content_type="article",
+    )
+
+
+def test_provenance_rooted_tree_passes_with_valid_chain(tmp_vault):
+    # Build a valid chain: seed → child1 → child2, plus a few more non-seeds
+    # pointing at the seed or each other. 6+ sources so the rule activates.
+    _write_source(tmp_vault, "Seed Source", "seed-one", body="Seminal paper on X.")
+    _write_source(tmp_vault, "Child A", "child-a", body="*Suggested by [[seed-one]] — follow-up citation*\n\nDerivative work.")
+    _write_source(tmp_vault, "Child B", "child-b", body="*Suggested by [[seed-one]] — cross-reference*\n\nRelated analysis.")
+    _write_source(tmp_vault, "Grandchild", "grandchild", body="*Suggested by [[child-a]] — deeper dive*\n\nMore content.")
+    _write_source(tmp_vault, "Extra seed", "seed-two", body="Another primary source.")
+    _write_source(tmp_vault, "Child C", "child-c", body="*Suggested by [[seed-two]] — reply*\n\nCritical response.")
+    tmp_vault.auto_sync()
+
+    code, out = _run_lint(tmp_vault, rule="provenance")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
+    assert issues == [], f"expected no issues, got: {issues}"
+
+
+def test_provenance_fails_when_all_sources_are_seeds(tmp_vault):
+    # 6 sources, zero breadcrumbs — flat batch, rule must fire.
+    for i in range(6):
+        _write_source(tmp_vault, f"Source {i}", f"source-{i}")
+    tmp_vault.auto_sync()
+
+    code, out = _run_lint(tmp_vault, rule="provenance")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
+    assert len(issues) >= 1
+    assert any("ZERO" in i["message"] or "no seed" in i["message"].lower() or "bouncing reading loop" in i["message"] for i in issues)
+
+
+def test_provenance_fails_on_dangling_breadcrumb(tmp_vault):
+    # Six sources; one of them references a non-existent note.
+    _write_source(tmp_vault, "Seed", "seed-one")
+    _write_source(tmp_vault, "Child A", "child-a", body="*Suggested by [[seed-one]] — real*\n")
+    _write_source(tmp_vault, "Child B", "child-b", body="*Suggested by [[seed-one]] — real*\n")
+    _write_source(tmp_vault, "Dangler", "dangler", body="*Suggested by [[nonexistent-note]] — fake*\n")
+    _write_source(tmp_vault, "Child C", "child-c", body="*Suggested by [[seed-one]] — real*\n")
+    _write_source(tmp_vault, "Child D", "child-d", body="*Suggested by [[seed-one]] — real*\n")
+    tmp_vault.auto_sync()
+
+    code, out = _run_lint(tmp_vault, rule="provenance")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
+    assert any("nonexistent-note" in i["message"] for i in issues), (
+        f"expected dangling breadcrumb issue, got: {issues}"
+    )
+
+
+def test_provenance_small_corpus_is_skipped(tmp_vault):
+    # <= 5 sources, rule should not complain (loop may not have fired by design).
+    for i in range(3):
+        _write_source(tmp_vault, f"Source {i}", f"source-{i}")
+    tmp_vault.auto_sync()
+
+    code, out = _run_lint(tmp_vault, rule="provenance")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
+    assert issues == []
+
+
+def test_provenance_errors_on_under_30pct_non_seed_ratio(tmp_vault):
+    """The guided reading loop must actually fire. A large corpus with only
+    a token 1-2 breadcrumbs should ERROR, not just warn. This is the exact
+    failure mode both v2 runs exhibited (3/19 and 2/33 breadcrumbs)."""
+    # 11 sources, 2 of them with breadcrumbs = 18% non-seed (below 30%)
+    _write_source(tmp_vault, "Seed 1", "seed-one")
+    _write_source(tmp_vault, "Seed 2", "seed-two")
+    for i in range(9):
+        # 2 of the 9 have breadcrumbs; rest are seeds
+        if i < 2:
+            body = f"*Suggested by [[seed-one]] — from analyst*\n\nContent {i}"
+        else:
+            body = f"Content {i}"
+        _write_source(tmp_vault, f"Source {i}", f"source-{i}", body=body)
+    tmp_vault.auto_sync()
+
+    code, out = _run_lint(tmp_vault, rule="provenance")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
+    errors = [i for i in issues if i.get("severity") == "error"]
+    assert len(errors) >= 1
+    assert "guided reading loop did not fire" in errors[0]["message"]
+
+
+def test_orphaned_raw_files_flags_disk_leak(tmp_vault):
+    """Files in research/raw/ with no matching note should be flagged."""
+    raw_dir = tmp_vault.root / "research" / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    # Create a raw file whose stem doesn't match any note.
+    (raw_dir / "orphan-note.pdf").write_bytes(b"%PDF-1.4 dummy")
+    tmp_vault.auto_sync()
+
+    code, out = _run_lint(tmp_vault, rule="orphaned-raw-files")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "orphaned-raw-files"]
+    assert len(issues) == 1
+    assert "orphan-note" in issues[0]["message"]
+
+
+def _write_audit_findings(vault, data: dict) -> None:
+    import json as _json
+    audit_path = vault.root / "research" / "audit_findings.json"
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text(_json.dumps(data, indent=2), encoding="utf-8")
+
+
+def test_audit_gate_missing_file_is_open(tmp_vault):
+    """No audit file = gate is OPEN (early-stage research)."""
+    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    assert code == 0
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
+    assert issues == []
+
+
+def test_audit_gate_blocks_unresolved_criticals(tmp_vault):
+    _write_audit_findings(tmp_vault, {
+        "runs": [
+            {
+                "mode": "conformance",
+                "timestamp": "2026-04-14T10:00:00Z",
+                "status": "needs_fixes",
+                "criticals": [
+                    {"id": "C0", "description": "Scaffold missing verbatim prompt", "fixed_at": None},
+                    {"id": "C1", "description": "Silver Saints omitted", "fixed_at": None},
+                ],
+                "important": [],
+                "minor": [],
+            }
+        ]
+    })
+    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
+    assert len(issues) == 1
+    assert "2 unresolved CRITICAL" in issues[0]["message"]
+
+
+def test_audit_gate_passes_when_all_criticals_fixed(tmp_vault):
+    """A CRITICAL with a vague description that doesn't map to any lint rule
+    should emit a WARNING (unverified agent self-report) but NOT an error —
+    the save gate still opens because warnings don't block."""
+    _write_audit_findings(tmp_vault, {
+        "runs": [
+            {
+                "mode": "conformance",
+                "timestamp": "2026-04-14T10:00:00Z",
+                "status": "pass",
+                "criticals": [
+                    {"id": "C0", "description": "generic content fix", "fixed_at": "2026-04-14T11:00:00Z"},
+                ],
+                "important": [],
+                "minor": [],
+            }
+        ]
+    })
+    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
+    errors = [i for i in issues if i.get("severity") == "error"]
+    warnings = [i for i in issues if i.get("severity") == "warning"]
+    # Save gate stays open (no errors) but emits a warning about the
+    # unverified self-report.
+    assert errors == []
+    assert len(warnings) == 1
+    assert "not machine-verified" in warnings[0]["message"]
+
+
+def test_audit_gate_uses_most_recent_conformance_run(tmp_vault):
+    """If a later run has fixes applied, the gate should pass even if older
+    runs had unresolved findings."""
+    _write_audit_findings(tmp_vault, {
+        "runs": [
+            {
+                "mode": "conformance",
+                "timestamp": "2026-04-14T10:00:00Z",
+                "status": "needs_fixes",
+                "criticals": [
+                    {"id": "C0", "description": "old finding", "fixed_at": None},
+                ],
+                "important": [], "minor": [],
+            },
+            {
+                "mode": "conformance",
+                "timestamp": "2026-04-14T12:00:00Z",
+                "status": "pass",
+                "criticals": [],
+                "important": [], "minor": [],
+            },
+        ]
+    })
+    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
+    assert issues == []
+
+
+def test_audit_gate_fails_when_only_comprehensiveness_run_exists(tmp_vault):
+    """A file with only comprehensiveness runs means the conformance auditor
+    never fired. The save gate must fail in that case."""
+    _write_audit_findings(tmp_vault, {
+        "runs": [
+            {
+                "mode": "comprehensiveness",
+                "timestamp": "2026-04-14T10:00:00Z",
+                "status": "needs_fixes",
+                "criticals": [],
+                "important": [
+                    {"id": "I1", "description": "some gap", "fixed_at": None},
+                ],
+                "minor": [],
+            }
+        ]
+    })
+    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
+    # Expect: one error for missing conformance, one info for important findings.
+    errors = [i for i in issues if i.get("severity") == "error"]
+    infos = [i for i in issues if i.get("severity") == "info"]
+    assert len(errors) == 1
+    assert "ZERO" in errors[0]["message"] and "conformance" in errors[0]["message"]
+    assert len(infos) == 1
+    assert "IMPORTANT" in infos[0]["message"]
+
+
+def test_audit_gate_surfaces_important_findings_as_info(tmp_vault):
+    """Unresolved IMPORTANT findings should surface as info-severity issues
+    (advisory), not block save."""
+    _write_audit_findings(tmp_vault, {
+        "runs": [
+            {
+                "mode": "conformance",
+                "timestamp": "2026-04-14T10:00:00Z",
+                "status": "pass",
+                "criticals": [],
+                "important": [
+                    {"id": "I1", "description": "Proportional depth uneven", "fixed_at": None},
+                    {"id": "I2", "description": "Citation to unfetched source", "fixed_at": None},
+                ],
+                "minor": [],
+            }
+        ]
+    })
+    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
+    errors = [i for i in issues if i.get("severity") == "error"]
+    infos = [i for i in issues if i.get("severity") == "info"]
+    assert errors == []  # save is NOT blocked by IMPORTANT alone
+    assert len(infos) == 1
+    assert "2 unresolved IMPORTANT" in infos[0]["message"]
+
+
+def test_audit_gate_catches_self_certification_on_provenance(tmp_vault):
+    """Regression test: when a CRITICAL finding mentions provenance AND is
+    marked `fixed_at`, but the provenance rule still returns errors, the
+    audit-gate must emit a SELF-CERTIFICATION VIOLATION error.
+
+    This is exactly the Q62 failure mode — the agent marked the C1
+    provenance finding as fixed with a justification string, but the
+    vault's actual breadcrumb graph was still broken.
+    """
+    # Build a vault where provenance is genuinely broken (12 sources, none
+    # with breadcrumbs — classic flat batch).
+    for i in range(12):
+        _write_source(tmp_vault, f"Source {i}", f"source-{i}")
+    tmp_vault.auto_sync()
+
+    # Audit findings file: conformance run with a CRITICAL marked fixed_at
+    # that references provenance. The "fix" is a lie — the vault still fails
+    # the provenance rule.
+    _write_audit_findings(tmp_vault, {
+        "runs": [
+            {
+                "mode": "conformance",
+                "timestamp": "2026-04-14T20:00:00Z",
+                "status": "pass",
+                "criticals": [
+                    {
+                        "id": "C1",
+                        "description": "Provenance chain broken — no --suggested-by breadcrumbs in corpus",
+                        "fixed_at": "2026-04-14T20:20:00Z",
+                    }
+                ],
+                "important": [],
+                "minor": [],
+            }
+        ]
+    })
+
+    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    import json
+    data = json.loads(out)
+    issues = data.get("data", {}).get("issues", [])
+    audit_errors = [
+        i for i in issues
+        if i.get("rule") == "audit-gate" and i.get("severity") == "error"
+    ]
+    self_cert_errors = [
+        i for i in audit_errors if "SELF-CERTIFICATION VIOLATION" in i["message"]
+    ]
+    assert len(self_cert_errors) == 1, f"expected self-cert violation, got: {audit_errors}"
+    assert "C1" in self_cert_errors[0]["message"]
+    assert "provenance" in self_cert_errors[0]["message"]
+
+
+def test_audit_gate_no_self_cert_when_fix_genuinely_landed(tmp_vault):
+    """Control: when CRITICAL fixed_at IS set AND the underlying lint rule
+    genuinely passes, the audit-gate should NOT emit a self-cert violation."""
+    # Build a vault where provenance is healthy (seed + 6 non-seeds, all
+    # pointing at real notes).
+    _write_source(tmp_vault, "Seed", "seed-one")
+    for i in range(6):
+        _write_source(
+            tmp_vault, f"Child {i}", f"child-{i}",
+            body=f"*Suggested by [[seed-one]] — real*\n\nContent {i}"
+        )
+    tmp_vault.auto_sync()
+
+    _write_audit_findings(tmp_vault, {
+        "runs": [
+            {
+                "mode": "conformance",
+                "timestamp": "2026-04-14T20:00:00Z",
+                "status": "pass",
+                "criticals": [
+                    {
+                        "id": "C1",
+                        "description": "provenance was broken earlier",
+                        "fixed_at": "2026-04-14T20:20:00Z",
+                    }
+                ],
+                "important": [],
+                "minor": [],
+            }
+        ]
+    })
+
+    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    import json
+    data = json.loads(out)
+    issues = data.get("data", {}).get("issues", [])
+    self_cert_errors = [
+        i for i in issues
+        if i.get("rule") == "audit-gate" and "SELF-CERTIFICATION VIOLATION" in i.get("message", "")
+    ]
+    assert self_cert_errors == [], f"false-positive self-cert: {self_cert_errors}"
+
+
+def test_audit_gate_handles_malformed_file(tmp_vault):
+    audit_path = tmp_vault.root / "research" / "audit_findings.json"
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text("{ not valid json }", encoding="utf-8")
+    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
+    assert len(issues) == 1
+    assert "malformed" in issues[0]["message"]
+
+
+def test_orphaned_raw_files_ignores_matched_raw(tmp_vault):
+    """Raw files whose stem matches a note id are not orphans."""
+    write_note(
+        tmp_vault.notes_dir,
+        "PDF Note",
+        note_id="real-pdf-note",
+        source="https://example.com/paper.pdf",
+        tier="ground_truth",
+        content_type="paper",
+        extra_frontmatter={"raw_file": "raw/real-pdf-note.pdf"},
+    )
+    raw_dir = tmp_vault.root / "research" / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "real-pdf-note.pdf").write_bytes(b"%PDF-1.4 dummy")
+    tmp_vault.auto_sync()
+
+    code, out = _run_lint(tmp_vault, rule="orphaned-raw-files")
+    import json
+    data = json.loads(out)
+    issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "orphaned-raw-files"]
+    assert issues == []

--- a/tests/test_cli/test_lint.py
+++ b/tests/test_cli/test_lint.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 from typer.testing import CliRunner
 
 from hyperresearch.cli.lint import app as lint_app
@@ -68,7 +67,7 @@ def test_scaffold_prompt_fails_when_header_missing(tmp_vault):
             "1. Cosmology\n"
         ),
     )
-    code, out = _run_lint(tmp_vault, rule="scaffold-prompt")
+    _, out = _run_lint(tmp_vault, rule="scaffold-prompt")
     import json
     data = json.loads(out)
     issues = data.get("data", {}).get("issues", [])
@@ -88,7 +87,7 @@ def test_scaffold_prompt_warns_when_quote_too_short(tmp_vault):
             "- thing\n"
         ),
     )
-    code, out = _run_lint(tmp_vault, rule="scaffold-prompt")
+    _, out = _run_lint(tmp_vault, rule="scaffold-prompt")
     import json
     data = json.loads(out)
     issues = data.get("data", {}).get("issues", [])
@@ -131,7 +130,7 @@ def test_provenance_rooted_tree_passes_with_valid_chain(tmp_vault):
     _write_source(tmp_vault, "Child C", "child-c", body="*Suggested by [[seed-two]] — reply*\n\nCritical response.")
     tmp_vault.auto_sync()
 
-    code, out = _run_lint(tmp_vault, rule="provenance")
+    _, out = _run_lint(tmp_vault, rule="provenance")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
@@ -144,7 +143,7 @@ def test_provenance_fails_when_all_sources_are_seeds(tmp_vault):
         _write_source(tmp_vault, f"Source {i}", f"source-{i}")
     tmp_vault.auto_sync()
 
-    code, out = _run_lint(tmp_vault, rule="provenance")
+    _, out = _run_lint(tmp_vault, rule="provenance")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
@@ -162,7 +161,7 @@ def test_provenance_fails_on_dangling_breadcrumb(tmp_vault):
     _write_source(tmp_vault, "Child D", "child-d", body="*Suggested by [[seed-one]] — real*\n")
     tmp_vault.auto_sync()
 
-    code, out = _run_lint(tmp_vault, rule="provenance")
+    _, out = _run_lint(tmp_vault, rule="provenance")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
@@ -177,7 +176,7 @@ def test_provenance_small_corpus_is_skipped(tmp_vault):
         _write_source(tmp_vault, f"Source {i}", f"source-{i}")
     tmp_vault.auto_sync()
 
-    code, out = _run_lint(tmp_vault, rule="provenance")
+    _, out = _run_lint(tmp_vault, rule="provenance")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
@@ -200,7 +199,7 @@ def test_provenance_errors_on_under_30pct_non_seed_ratio(tmp_vault):
         _write_source(tmp_vault, f"Source {i}", f"source-{i}", body=body)
     tmp_vault.auto_sync()
 
-    code, out = _run_lint(tmp_vault, rule="provenance")
+    _, out = _run_lint(tmp_vault, rule="provenance")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "provenance"]
@@ -217,7 +216,7 @@ def test_orphaned_raw_files_flags_disk_leak(tmp_vault):
     (raw_dir / "orphan-note.pdf").write_bytes(b"%PDF-1.4 dummy")
     tmp_vault.auto_sync()
 
-    code, out = _run_lint(tmp_vault, rule="orphaned-raw-files")
+    _, out = _run_lint(tmp_vault, rule="orphaned-raw-files")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "orphaned-raw-files"]
@@ -258,7 +257,7 @@ def test_audit_gate_blocks_unresolved_criticals(tmp_vault):
             }
         ]
     })
-    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    _, out = _run_lint(tmp_vault, rule="audit-gate")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
@@ -284,7 +283,7 @@ def test_audit_gate_passes_when_all_criticals_fixed(tmp_vault):
             }
         ]
     })
-    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    _, out = _run_lint(tmp_vault, rule="audit-gate")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
@@ -320,7 +319,7 @@ def test_audit_gate_uses_most_recent_conformance_run(tmp_vault):
             },
         ]
     })
-    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    _, out = _run_lint(tmp_vault, rule="audit-gate")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
@@ -344,7 +343,7 @@ def test_audit_gate_fails_when_only_comprehensiveness_run_exists(tmp_vault):
             }
         ]
     })
-    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    _, out = _run_lint(tmp_vault, rule="audit-gate")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
@@ -375,7 +374,7 @@ def test_audit_gate_surfaces_important_findings_as_info(tmp_vault):
             }
         ]
     })
-    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    _, out = _run_lint(tmp_vault, rule="audit-gate")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
@@ -423,7 +422,7 @@ def test_audit_gate_catches_self_certification_on_provenance(tmp_vault):
         ]
     })
 
-    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    _, out = _run_lint(tmp_vault, rule="audit-gate")
     import json
     data = json.loads(out)
     issues = data.get("data", {}).get("issues", [])
@@ -471,7 +470,7 @@ def test_audit_gate_no_self_cert_when_fix_genuinely_landed(tmp_vault):
         ]
     })
 
-    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    _, out = _run_lint(tmp_vault, rule="audit-gate")
     import json
     data = json.loads(out)
     issues = data.get("data", {}).get("issues", [])
@@ -486,7 +485,7 @@ def test_audit_gate_handles_malformed_file(tmp_vault):
     audit_path = tmp_vault.root / "research" / "audit_findings.json"
     audit_path.parent.mkdir(parents=True, exist_ok=True)
     audit_path.write_text("{ not valid json }", encoding="utf-8")
-    code, out = _run_lint(tmp_vault, rule="audit-gate")
+    _, out = _run_lint(tmp_vault, rule="audit-gate")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "audit-gate"]
@@ -510,7 +509,7 @@ def test_orphaned_raw_files_ignores_matched_raw(tmp_vault):
     (raw_dir / "real-pdf-note.pdf").write_bytes(b"%PDF-1.4 dummy")
     tmp_vault.auto_sync()
 
-    code, out = _run_lint(tmp_vault, rule="orphaned-raw-files")
+    _, out = _run_lint(tmp_vault, rule="orphaned-raw-files")
     import json
     data = json.loads(out)
     issues = [i for i in data.get("data", {}).get("issues", []) if i.get("rule") == "orphaned-raw-files"]

--- a/tests/test_cli/test_note_ops.py
+++ b/tests/test_cli/test_note_ops.py
@@ -38,6 +38,55 @@ def test_note_rm_nonexistent(vault_with_notes):
     assert result.exit_code == 1
 
 
+def test_note_rm_cleans_raw_file_and_assets(vault_with_notes):
+    """note rm must delete the raw file and assets directory, not just the .md.
+
+    Regression test for Batch 2.5 — prior to this, `note rm` only unlinked
+    the `.md` file and raw/assets leaked on disk forever.
+    """
+    vault_root = vault_with_notes
+
+    # Seed a note with raw_file in its frontmatter and an assets directory.
+    from hyperresearch.core.note import write_note
+    from hyperresearch.core.vault import Vault
+    vault = Vault.discover()
+
+    write_note(
+        vault.notes_dir,
+        "PDF Source",
+        note_id="pdf-source",
+        source="https://example.com/paper.pdf",
+        tier="ground_truth",
+        content_type="paper",
+        extra_frontmatter={"raw_file": "raw/pdf-source.pdf"},
+    )
+
+    raw_dir = vault_root / "research" / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    raw_file = raw_dir / "pdf-source.pdf"
+    raw_file.write_bytes(b"%PDF-1.4 test")
+
+    assets_dir = vault_root / "research" / "assets" / "pdf-source"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    (assets_dir / "screenshot.png").write_bytes(b"PNG fake")
+    (assets_dir / "figure-1.jpg").write_bytes(b"JPG fake")
+
+    runner.invoke(app, ["sync"])
+
+    # Delete it
+    result = runner.invoke(app, ["note", "rm", "pdf-source", "--force", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["ok"] is True
+    assert data["data"]["deleted"] == "pdf-source"
+    assert data["data"].get("removed_raw") == "research/raw/pdf-source.pdf"
+    assert len(data["data"].get("removed_assets", [])) == 2
+
+    # Verify the files are actually gone from disk.
+    assert not raw_file.exists(), "raw file should have been deleted"
+    assert not assets_dir.exists(), "assets directory should have been removed"
+
+
 def test_note_mv(vault_with_notes):
     result = runner.invoke(
         app, ["note", "mv", "beta-note", "notes/moved/beta-note.md", "--json"]

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from hyperresearch.core.hooks import _SKILL_FILES, _install_research_skill
 
 

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -1,0 +1,50 @@
+"""Tests for hook installer and skill file provisioning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hyperresearch.core.hooks import _SKILL_FILES, _install_research_skill
+
+
+def test_install_skill_writes_expected_files(tmp_vault):
+    result = _install_research_skill(tmp_vault.root)
+    skill_dir = tmp_vault.root / ".claude" / "skills" / "hyperresearch"
+    assert skill_dir.is_dir()
+
+    expected = {dest_name for _, dest_name in _SKILL_FILES}
+    present = {p.name for p in skill_dir.glob("SKILL*.md")}
+    assert expected.issubset(present)
+    assert result is not None
+
+
+def test_install_skill_prunes_stale_files(tmp_vault):
+    skill_dir = tmp_vault.root / ".claude" / "skills" / "hyperresearch"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+
+    # Simulate a pre-refactor vault with the old modality files present.
+    stale_names = [
+        "SKILL-humanities.md",
+        "SKILL-academic.md",
+        "SKILL-landscape.md",
+        "SKILL-technical.md",
+    ]
+    for name in stale_names:
+        (skill_dir / name).write_text("stale content\n", encoding="utf-8")
+
+    result = _install_research_skill(tmp_vault.root)
+
+    remaining = {p.name for p in skill_dir.glob("SKILL*.md")}
+    expected = {dest_name for _, dest_name in _SKILL_FILES}
+    assert remaining == expected
+    for name in stale_names:
+        assert not (skill_dir / name).exists(), f"stale file {name} still present"
+    assert result is not None
+    assert "pruned" in result
+
+
+def test_install_skill_idempotent_second_run(tmp_vault):
+    first = _install_research_skill(tmp_vault.root)
+    assert first is not None
+    second = _install_research_skill(tmp_vault.root)
+    assert second is None, "second run should report no changes"

--- a/tests/test_core/test_note.py
+++ b/tests/test_core/test_note.py
@@ -84,6 +84,38 @@ def test_strip_markdown():
     assert "[[" not in plain
 
 
+def test_raw_file_persists_on_roundtrip(tmp_vault):
+    """raw_file must survive parse + re-serialize (regression test for wipe bug).
+
+    Before Batch 1.2 fix: raw_file was injected into frontmatter as a string
+    AFTER write_note; NoteMeta.model_config = {"extra": "ignore"} silently
+    dropped the field on the next parse, and any re-serialization (repair,
+    note update) wiped it from disk.
+    """
+    from hyperresearch.core.frontmatter import parse_frontmatter, render_note
+
+    path = write_note(
+        tmp_vault.notes_dir,
+        "PDF Note",
+        body="# PDF content\n",
+        extra_frontmatter={"raw_file": "raw/pdf-note.pdf"},
+    )
+    # First read — does NoteMeta capture the field?
+    note = read_note(path, tmp_vault.root)
+    assert note.meta.raw_file == "raw/pdf-note.pdf"
+
+    # Re-serialize (simulates repair.py enrichment or note update).
+    text = path.read_text(encoding="utf-8")
+    meta, body = parse_frontmatter(text)
+    path.write_text(render_note(meta, body), encoding="utf-8")
+
+    # Second read — raw_file must still be present.
+    note2 = read_note(path, tmp_vault.root)
+    assert note2.meta.raw_file == "raw/pdf-note.pdf", (
+        "raw_file was wiped on re-serialize — Batch 1.2 regression"
+    )
+
+
 def test_read_utf8_content(tmp_vault):
     path = write_note(
         tmp_vault.notes_dir,

--- a/tests/test_core/test_patterns.py
+++ b/tests/test_core/test_patterns.py
@@ -1,0 +1,133 @@
+"""Tests for wiki-link target validation — citation-footnote edge cases."""
+
+from hyperresearch.core.patterns import is_valid_wiki_link_target
+
+
+def test_empty_and_whitespace_rejected():
+    assert not is_valid_wiki_link_target("")
+    assert not is_valid_wiki_link_target("   ")
+    assert not is_valid_wiki_link_target("\n")
+
+
+def test_urls_rejected():
+    assert not is_valid_wiki_link_target("https://example.com/foo")
+    assert not is_valid_wiki_link_target("http://example.com")
+    assert not is_valid_wiki_link_target("ftp://files.example.com")
+    assert not is_valid_wiki_link_target("mailto:jordan@example.com")
+
+
+def test_anchors_and_paths_rejected():
+    assert not is_valid_wiki_link_target("#section-1")
+    assert not is_valid_wiki_link_target("/path/to/note")
+
+
+def test_pure_numeric_citation_footnotes_rejected():
+    # The Q91 bug: Wikipedia footnotes rendered as [[100]]
+    assert not is_valid_wiki_link_target("100")
+    assert not is_valid_wiki_link_target("1")
+    assert not is_valid_wiki_link_target("999")
+
+
+def test_caret_prefixed_footnotes_rejected():
+    # Markdown-standard footnote syntax
+    assert not is_valid_wiki_link_target("^1")
+    assert not is_valid_wiki_link_target("^100")
+
+
+def test_multi_number_citations_rejected():
+    # Comma/semicolon/dash-separated citation groups
+    assert not is_valid_wiki_link_target("100,101")
+    assert not is_valid_wiki_link_target("1, 2, 3")
+    assert not is_valid_wiki_link_target("100; 101")
+    assert not is_valid_wiki_link_target("1-5")
+    assert not is_valid_wiki_link_target("100-105")
+
+
+def test_cite_prefix_patterns_rejected():
+    assert not is_valid_wiki_link_target("cite-1")
+    assert not is_valid_wiki_link_target("cite_2")
+    assert not is_valid_wiki_link_target("cite:3")
+    assert not is_valid_wiki_link_target("ref-42")
+    assert not is_valid_wiki_link_target("ref_42")
+    assert not is_valid_wiki_link_target("fn-1")
+    assert not is_valid_wiki_link_target("fn:2")
+    assert not is_valid_wiki_link_target("note-5")
+    assert not is_valid_wiki_link_target("footnote-10")
+    assert not is_valid_wiki_link_target("endnote-3")
+
+
+def test_cite_prefixes_are_case_insensitive():
+    assert not is_valid_wiki_link_target("Cite-1")
+    assert not is_valid_wiki_link_target("REF_2")
+    assert not is_valid_wiki_link_target("Fn-3")
+
+
+def test_valid_note_ids_accepted():
+    # Real note IDs should pass through
+    assert is_valid_wiki_link_target("pegasus-seiya")
+    assert is_valid_wiki_link_target("the-comics-journal-soldier-dream")
+    assert is_valid_wiki_link_target("quantum-computing")
+    assert is_valid_wiki_link_target("scaffold-saint-seiya")
+
+
+def test_note_ids_starting_with_digits_accepted():
+    # [[10-rules-for-X]] or [[1984-novel]] must pass — they contain non-digit chars
+    assert is_valid_wiki_link_target("10-rules-for-typescript")
+    assert is_valid_wiki_link_target("1984-novel")
+    assert is_valid_wiki_link_target("100-greatest-films")
+
+
+def test_note_ids_that_contain_cite_word_accepted():
+    # "citation" is not "cite-N" — should pass
+    assert is_valid_wiki_link_target("citations-are-important")
+    assert is_valid_wiki_link_target("references-guide")
+    assert is_valid_wiki_link_target("note-taking-systems")  # plural, no digit
+
+
+def test_whitespace_is_stripped():
+    # Leading/trailing whitespace should be stripped before evaluation
+    assert not is_valid_wiki_link_target("  100  ")
+    assert not is_valid_wiki_link_target("\t^100\n")
+    assert is_valid_wiki_link_target("  valid-note-id  ")
+
+
+def test_roman_numeral_footnotes_rejected():
+    # Academic papers use Roman numerals for appendix/preface footnotes.
+    assert not is_valid_wiki_link_target("i")
+    assert not is_valid_wiki_link_target("iv")
+    assert not is_valid_wiki_link_target("xii")
+    assert not is_valid_wiki_link_target("xxiv")
+    assert not is_valid_wiki_link_target("IV")
+    assert not is_valid_wiki_link_target("XIV")
+
+
+def test_symbol_footnotes_rejected():
+    # Typography-style footnote markers used in older academic publishing.
+    assert not is_valid_wiki_link_target("*")
+    assert not is_valid_wiki_link_target("**")
+    assert not is_valid_wiki_link_target("†")
+    assert not is_valid_wiki_link_target("‡")
+    assert not is_valid_wiki_link_target("§")
+    assert not is_valid_wiki_link_target("¶")
+
+
+def test_document_cross_references_rejected():
+    # Figure / table / equation refs are document-internal, not wiki-links.
+    assert not is_valid_wiki_link_target("fig-3")
+    assert not is_valid_wiki_link_target("figure-4b")
+    assert not is_valid_wiki_link_target("tab-1")
+    assert not is_valid_wiki_link_target("table-2")
+    assert not is_valid_wiki_link_target("eq-2")
+    assert not is_valid_wiki_link_target("equation-7")
+    assert not is_valid_wiki_link_target("scheme-3")
+    assert not is_valid_wiki_link_target("algorithm-2")
+    assert not is_valid_wiki_link_target("Fig-1")  # case-insensitive
+
+
+def test_real_words_that_look_like_roman_are_accepted():
+    # "dim" and "mix" look roman-like but are real note ids
+    assert is_valid_wiki_link_target("mix-matrix")
+    assert is_valid_wiki_link_target("div-container")
+    # Longer words containing roman chars are fine
+    assert is_valid_wiki_link_target("civic")
+    assert is_valid_wiki_link_target("minimalism")

--- a/tests/test_core/test_sync.py
+++ b/tests/test_core/test_sync.py
@@ -96,3 +96,30 @@ def test_sync_excludes_hyperresearch_dir(tmp_vault):
     (tmp_vault.root / ".hyperresearch" / "test.md").write_text("---\ntitle: Bad\n---\nShould not sync")
     plan = compute_sync_plan(tmp_vault)
     assert all(".hyperresearch" not in str(p) for p in plan.to_add)
+
+
+def test_sync_excludes_research_root_staging_files(tmp_vault):
+    """Files at research/ root (scaffold.md, comparisons.md, synthesis.md)
+    are staging files the agent writes then registers via `note new`. They
+    must NOT appear as orphan notes in the vault index — the current
+    behavior would produce missing-title/tags/summary lint spam on every run.
+    """
+    from hyperresearch.core.note import write_note
+
+    # Real notes under research/notes/
+    write_note(tmp_vault.notes_dir, "Real Note", body="# Real\n")
+
+    # Staging files at research/ root
+    research_root = tmp_vault.research_dir
+    (research_root / "scaffold.md").write_text("# Scaffold staging\n")
+    (research_root / "comparisons.md").write_text("# Comparisons staging\n")
+    (research_root / "synthesis.md").write_text("# Synthesis staging\n")
+
+    plan = compute_sync_plan(tmp_vault)
+
+    # Only the real note should be added.
+    added_names = [p.name for p in plan.to_add]
+    assert "real-note.md" in added_names
+    assert "scaffold.md" not in added_names
+    assert "comparisons.md" not in added_names
+    assert "synthesis.md" not in added_names


### PR DESCRIPTION
## Summary

- **4-activity modality taxonomy** (`collect` / `synthesize` / `compare` / `forecast`) replaces v0.4.0's 7-type subject-based classification. The dispatcher routes by what the output needs to *do*, not what the subject *is*. One dispatcher (`research.md`) owns the shared 14-step protocol; four thin modality files encode only substance differences.
- **Verbatim-prompt gospel rule** — the user's prompt is pasted into `research/scaffold.md` §1 and re-read at every downstream step. Machine-checked via the new `scaffold-prompt` lint rule at Checkpoint 3.
- **Audit-gate self-certification detector** — when an auditor CRITICAL is marked `fixed_at`, the gate extracts a keyword from the description (provenance / analyst-coverage / scaffold-prompt / workflow / uncurated), re-runs that lint rule in-process, and emits a `SELF-CERTIFICATION VIOLATION` if the rule still fails. Save is blocked.
- **Rooted-tree provenance check** — `--suggested-by` chain must form an actual tree from at least one seed; isolated breadcrumbs and disconnected components are flagged as errors. Forces the guided reading loop to actually fire (not flat batch fetches).
- **Adversarial dissent mandate** — Checkpoint 1 requires at least one source explicitly dissents from the dominant view. All 4 modality files have sharpened "MANDATORY, run all N before proceeding" adversarial rounds with named-critic search guidance.
- **Audit findings persisted** — `research/audit_findings.json` is the structured record of every audit run. The `hyperresearch-auditor` subagent uses the Write tool to persist directly (not Bash redirection — that was flaky in earlier iterations).
- **Three registered subagents** for Claude Code: `hyperresearch-fetcher` (Haiku, mechanical URL fetching), `hyperresearch-analyst` (Sonnet, guided reading + extraction), `hyperresearch-auditor` (Opus, adversarial review).
- **Schema v6** — `tier` and `content_type` columns added to `notes` (CHECK-constrained vocabularies), `raw_file` field on `NoteMeta` (fixes a silent data-loss bug where PDF artifacts were lost on re-serialize).
- **Fetch resilience** — when a high-priority source fails, the agent walks a fallback chain: alternative URLs (preprint server, author page, institutional repo) → `--visible` browser flag → configured login profile → summary-fallback. Failures get documented; nothing silently disappears.
- **Data integrity fixes** — `INSERT OR IGNORE` on the sources race, raw-file persistence through NoteMeta, `note rm` cleans raw files + assets directory (with path-traversal guard), sync excludes `research/*.md` staging files.

## File structure

| Layer | What changed |
|---|---|
| Schema | `core/db.py` v5→v6, `core/migrations.py` (idempotent ADD COLUMN), `models/note.py` (Tier, ContentType, raw_file enums + field) |
| Skill system | `skills/research.md` rewrite (~700 lines) + 4 new modality files (~120-200 lines each), `core/agent_docs.py` template |
| Subagents | `core/hooks.py` AUDITOR_AGENT (~300 lines) + ANALYST_AGENT + FETCHER_AGENT, install pipeline with stale-file pruning |
| Lint | `cli/lint.py` 5 new rules (scaffold-prompt, audit-gate, orphaned-raw-files) + 2 rewrites (provenance rooted-tree, analyst-coverage) |
| Data integrity | `cli/fetch.py`, `cli/note.py`, `core/sync.py`, `core/patterns.py` |
| Tests | +30 new test cases across `tests/test_cli/test_lint.py` (NEW), `test_core/test_hooks.py` (NEW), `test_core/test_patterns.py` (NEW), additions to test_note, test_sync, test_note_ops |
| Docs | `README.md` rewrite with 4 mermaid architecture diagrams |

## Test plan

- [x] `ruff check src/ tests/` — All checks passed
- [x] `pytest tests/` — 112 passing
- [x] AST sweep across `src/hyperresearch/**.py` — zero syntax errors
- [x] Smoke test on fresh temp vault — init creates v6 schema, all 5 new lint rules return 0 issues on clean vault, install lands 4 SKILL files + 3 agents + CLAUDE.md
- [x] Live audit-gate verification — emits SELF-CERTIFICATION VIOLATION when CRITICAL marked fixed but underlying rule still fails (regression test in `test_lint.py`)
- [x] `raw_file` survives Read+parse+Write round-trip (regression test for the silent-wipe bug)
- [ ] CI matrix on Python 3.11/3.12/3.13 — verifies on push

## Migration notes

Existing v5 vaults migrate idempotently on first `hyperresearch` command — the v6 migration runs `ALTER TABLE notes ADD COLUMN tier`, `ADD COLUMN content_type`. Existing notes get `tier=NULL, content_type=NULL` until re-curated.

Pre-v0.5.0 `.claude/skills/hyperresearch/` directories with stale `SKILL-humanities.md` / `SKILL-academic.md` / `SKILL-landscape.md` / `SKILL-technical.md` get auto-pruned on next `hyperresearch install --agents claude`.

No breaking API changes for users of the `hyperresearch` CLI — all v0.4.0 commands still work, with new flags (`--tier`, `--content-type`, `--suggested-by`, `--visible`, `--rule scaffold-prompt|audit-gate|orphaned-raw-files`).