### PR TITLE
v0.8.1 — drop /research alias and standard tier, recalibrate times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.8.1] - 2026-04-29
+
+### Surface cleanup
+
+- **`/research` alias retired.** Only `/hyperresearch` remains. The `research` skill dir is now in `_RETIRED_SKILL_DIRS` and is pruned automatically on the next `hyperresearch install`.
+- **`standard` tier removed.** Only `light` and `full` remain. Step 1's classifier folds the previous standard-tier signals (surveys, multi-entity comparisons, landscape overviews) into `light`. Mid-tier fan-out (3 critics, 60–100 URLs, 40–60 claims) is gone — the simplification is intentional.
+- **Time estimates re-calibrated.** Light: ~30–40 minutes (was 3–8 min). Full: ~1.5–2.5 hours (was 25–60 min). Numbers reflect realistic wall-clock times observed across recent runs, not theoretical floors.
+- **README tier table** drops the cost column.
+
 ## [0.8.0] - 2026-04-29
 
 ### Architecture — V8.3 deployment release

--- a/README.md
+++ b/README.md
@@ -28,15 +28,14 @@ pip install hyperresearch
 hyperresearch install
 ```
 
-In Claude Code, type `/research <anything>` or `/hyperresearch <anything>` (they're aliases for the same pipeline). Step 1 classifies your query into one of three tiers and the rest of the pipeline scales accordingly:
+In Claude Code, type `/hyperresearch <anything>`. Step 1 classifies your query into one of two tiers and the rest of the pipeline scales accordingly:
 
-| Tier | Steps that run | Typical cost | Typical time |
-|---|---|---|---|
-| `light` | bounded factual queries — 1 → 2 → 10 → 15 → 16 | ~$3–8 | ~3–8 min |
-| `standard` | landscape surveys, multi-entity comparisons | ~$10–22 | ~10–22 min |
-| `full` | deep argumentative analysis with adversarial review | ~$35–65 | ~25–60 min |
+| Tier | Steps that run | Typical time |
+|---|---|---|
+| `light` | bounded factual queries, surveys, comparisons — 1 → 2 → 10 → 15 → 16 | ~30–40 min |
+| `full` | deep argumentative analysis with adversarial review — all 16 steps | ~1.5–2.5 hours |
 
-The single install command provisions a SQLite vault, auto-installs Chromium for headless browsing, generates `CLAUDE.md`, registers the entry skill at both `/research` and `/hyperresearch`, installs all 16 step skills, and wires the agent roster + PreToolUse hooks into `.claude/`.
+The single install command provisions a SQLite vault, auto-installs Chromium for headless browsing, generates `CLAUDE.md`, registers the `/hyperresearch` entry skill, installs all 16 step skills, and wires the agent roster + PreToolUse hooks into `.claude/`.
 
 ---
 
@@ -46,22 +45,22 @@ The entry skill is a thin **router**. It bootstraps the canonical research query
 
 | # | Step | What it does | Tiers |
 |---|---|---|---|
-| 1 | Decompose | Canonical query → atomic items + coverage matrix + tier classification | all |
-| 2 | Width sweep | Multi-perspective search plan + parallel fetcher waves (Haiku) | all |
-| 3 | Contradiction graph | Pair contradictions across the corpus into ranked clusters | std/full |
+| 1 | Decompose | Canonical query → atomic items + coverage matrix + tier classification | both |
+| 2 | Width sweep | Multi-perspective search plan + parallel fetcher waves (Haiku) | both |
+| 3 | Contradiction graph | Pair contradictions across the corpus into ranked clusters | full |
 | 4 | Loci analysis | Two parallel loci-analysts → scored loci with source budgets | full |
 | 5 | Depth investigation | K parallel depth-investigators → interim notes with committed positions | full |
 | 6 | Cross-locus reconcile | Reconcile committed positions → comparisons.md | full |
 | 7 | Source tensions | Extract expert disagreements → source-tensions.json | full |
 | 8 | Corpus critic | "What source would overturn this?" + targeted gap-fill fetch | full |
-| 9 | Evidence digest | Top claims + verbatim quotes → evidence-digest.md | std/full |
-| 10 | Triple draft | Per-angle source curation + 3 parallel draft sub-orchestrators | all |
-| 11 | Synthesize | Plan + outline + spawn synthesizer subagent → final_report.md | std/full |
-| 12 | Critics | 4 adversarial critics in parallel → findings JSONs | std/full |
-| 13 | Gap-fetch | Targeted fetch wave for critic-identified vault gaps | std/full |
-| 14 | Patcher | Surgical Edit hunks applied to draft (tool-locked Read+Edit) | std/full |
-| 15 | Polish | Hygiene + filler pass (tool-locked Read+Edit subagent) | all |
-| 16 | Readability audit | Recommender writes JSON suggestions; orchestrator selectively applies | all |
+| 9 | Evidence digest | Top claims + verbatim quotes → evidence-digest.md | full |
+| 10 | Triple draft | Per-angle source curation + 3 parallel draft sub-orchestrators (light: single draft) | both |
+| 11 | Synthesize | Plan + outline + spawn synthesizer subagent → final_report.md | full |
+| 12 | Critics | 4 adversarial critics in parallel → findings JSONs | full |
+| 13 | Gap-fetch | Targeted fetch wave for critic-identified vault gaps | full |
+| 14 | Patcher | Surgical Edit hunks applied to draft (tool-locked Read+Edit) | full |
+| 15 | Polish | Hygiene + filler pass (tool-locked Read+Edit subagent) | both |
+| 16 | Readability audit | Recommender writes JSON suggestions; orchestrator selectively applies | both |
 
 ### The two load-bearing invariants
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hyperresearch"
-version = "0.8.0"
+version = "0.8.1"
 description = "Claude Code harness for disciplined, adversarially-audited deep research with full provenance."
 readme = "README.md"
 license = "MIT"

--- a/src/hyperresearch/__init__.py
+++ b/src/hyperresearch/__init__.py
@@ -1,3 +1,3 @@
 """Hyperresearch — agent-driven research knowledge base."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/src/hyperresearch/cli/lint.py
+++ b/src/hyperresearch/cli/lint.py
@@ -26,7 +26,7 @@ RULES = {
     "locus-coverage": "Loci identified in Layer 2 missing their interim-report notes (depth investigator skipped)",
     "patch-surgery": "Critical critic findings skipped by the patcher (Layer 6 regeneration guard tripped)",
     "instruction-coverage": "Atomic items from prompt-decomposition missing from the final report (draft drifted from user's ask)",
-    "extract-coverage": "Single-pass /research runs with fetched sources but no paired extract notes (reading loop skipped or source-analyst not delegated for long sources)",
+    "extract-coverage": "Light-tier runs with fetched sources but no paired extract notes (reading loop skipped or source-analyst not delegated for long sources)",
     "orphaned-raw-files": "Files in research/raw/ with no matching note (disk leak from old note rm)",
     "singleton-tags": "Tags used by only one note",
     "broken-links": "Wiki-links that don't resolve",

--- a/src/hyperresearch/core/agent_docs.py
+++ b/src/hyperresearch/core/agent_docs.py
@@ -27,9 +27,9 @@ This project uses hyperresearch as an agent-driven research knowledge base. The 
 
 ### How to do research
 
-**Run a research session with `/hyperresearch <query>` or its alias `/research <query>`.** Both invoke the same V8 16-step pipeline. The entry skill at `.claude/skills/hyperresearch/SKILL.md` is a thin ROUTER. The 16 step procedures live in their own skills (`hyperresearch-1-decompose` through `hyperresearch-16-readability-audit`) and are loaded fresh into context via the `Skill` tool when each step runs. This solves V7's context-compaction problem: each step's procedure lands in context only when needed. Read the entry skill before you start a research session; it explains the chain mechanics.
+**Run a research session with `/hyperresearch <query>`.** This invokes the V8 16-step pipeline. The entry skill at `.claude/skills/hyperresearch/SKILL.md` is a thin ROUTER. The 16 step procedures live in their own skills (`hyperresearch-1-decompose` through `hyperresearch-16-readability-audit`) and are loaded fresh into context via the `Skill` tool when each step runs. This solves V7's context-compaction problem: each step's procedure lands in context only when needed. Read the entry skill before you start a research session; it explains the chain mechanics.
 
-Step 1 classifies the query into one of three tiers (`light` / `standard` / `full`) and the rest of the pipeline scales accordingly — short bounded queries skip the depth investigations, critics, and patcher; argumentative deep-research queries run the full 16 steps with adversarial review.
+Step 1 classifies the query into one of two tiers (`light` or `full`) and the rest of the pipeline scales accordingly — short bounded queries skip the depth investigations, critics, and patcher (~30-40 min); argumentative deep-research queries run all 16 steps with adversarial review (~1.5-2.5 hours).
 
 **Do NOT use WebFetch for source pages** — use `{hpr} fetch` instead. The skill files explain when to fetch vs. search.
 

--- a/src/hyperresearch/core/hooks.py
+++ b/src/hyperresearch/core/hooks.py
@@ -1,7 +1,7 @@
 """Agent hook installer — installs the Claude Code PreToolUse hook, skills, and subagents.
 
 The hook reminds Claude Code to check the research base before doing raw web
-searches. The skills (`/research`, `/hyperresearch`) drive the research
+searches. The `/hyperresearch` skill drives the research
 protocol. The hyperresearch subagents (fetcher, loci-analyst, depth-investigator,
 four critics, patcher, polish-auditor) are Claude Code registered agents
 spawned via the Task tool.
@@ -1273,8 +1273,7 @@ Concretely:
 
 1. **Read all four findings files** (dialectic / depth / width / instruction).
    Merge into one flat list. Sort by severity: critical first, then major, then minor.
-   Read whichever findings files exist — on standard tier, only width
-   and instruction findings are present. Skip missing files silently.
+   Skip any missing files silently (defensive — full tier writes all four).
 
    **Pre-filter: `requires_orchestrator_restructure` findings go straight to escalation.**
    Any finding with `requires_orchestrator_restructure: true`
@@ -3218,6 +3217,7 @@ _RETIRED_AGENT_FILES: tuple[str, ...] = (
 _RETIRED_SKILL_DIRS: tuple[str, ...] = (
     "research-ensemble",
     "research-layercake",  # superseded by /hyperresearch alias
+    "research",            # /research alias retired in v0.8.1 — only /hyperresearch now
 )
 
 # V1 modality files — left over inside .claude/skills/hyperresearch/ on
@@ -3295,37 +3295,23 @@ def _read_skill_source(src_name: str) -> str | None:
 
 
 def _install_hyperresearch_skill(vault_root: Path) -> str | None:
-    """Install the entry skill as both /hyperresearch and /research.
+    """Install the entry skill at .claude/skills/hyperresearch/SKILL.md.
 
-    Two skill directories are written from the single `hyperresearch.md`
-    source. The /research copy has its `name:` frontmatter rewritten so
-    Claude Code registers it as an independent slash-command trigger.
-    Both directories contain identical step instructions — they are
-    aliases for the same V8 pipeline. The 16 step skills are installed
-    separately by `_install_hyperresearch_step_skills`.
+    Claude Code registers `/hyperresearch` as the slash-command trigger via
+    the skill's `name: hyperresearch` frontmatter. The 16 step skills are
+    installed separately by `_install_hyperresearch_step_skills`.
     """
-    source = _read_skill_source("hyperresearch.md")
-    if source is None:
+    content = _read_skill_source("hyperresearch.md")
+    if content is None:
         return None
 
-    aliases = [
-        ("hyperresearch", source),
-        ("research", source.replace("name: hyperresearch", "name: research", 1)),
-    ]
-
-    written: list[str] = []
-    for alias, content in aliases:
-        skill_dir = vault_root / ".claude" / "skills" / alias
-        skill_dir.mkdir(parents=True, exist_ok=True)
-        dest_path = skill_dir / "SKILL.md"
-        if dest_path.exists() and dest_path.read_text(encoding="utf-8") == content:
-            continue
-        dest_path.write_text(content, encoding="utf-8")
-        written.append(f"/{alias}")
-
-    if not written:
+    skill_dir = vault_root / ".claude" / "skills" / "hyperresearch"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    dest_path = skill_dir / "SKILL.md"
+    if dest_path.exists() and dest_path.read_text(encoding="utf-8") == content:
         return None
-    return f"Claude Code: entry skill installed ({', '.join(written)} triggers)"
+    dest_path.write_text(content, encoding="utf-8")
+    return "Claude Code: .claude/skills/hyperresearch/SKILL.md (/hyperresearch trigger)"
 
 
 _HYPERRESEARCH_STEP_SKILLS = [

--- a/src/hyperresearch/skills/hyperresearch-1-decompose.md
+++ b/src/hyperresearch/skills/hyperresearch-1-decompose.md
@@ -104,11 +104,10 @@ Read both before starting. The vault_tag is in the scaffold's "Run config" secti
 
    | Tier | When to use | Signal words / patterns |
    |------|-------------|------------------------|
-   | `"light"` | Query has a clear, bounded answer. Factual lookup, definition, simple explanation, short how-to, list/catalog, quick comparison. | "What is...", "How do I...", "List the...", "Define...", short prompts (<50 words), single clear question |
-   | `"standard"` | Moderate coverage across a topic. Survey, landscape overview, current-state report, multi-entity comparison, decision support. | "Overview of...", "Compare X and Y", "What's the current state of...", moderate-length prompts, 2-5 sub-questions |
+   | `"light"` | Query has a clear, bounded answer. Factual lookup, definition, simple explanation, short how-to, list/catalog, quick comparison, landscape overview, multi-entity survey. | "What is...", "How do I...", "List the...", "Define...", "Overview of...", "Compare X and Y", short-to-moderate prompts, single clear question or 2–5 sub-questions |
    | `"full"` | Deep analysis, synthesis of conflicting evidence, defended thesis, literature review, forecast with evidence chains. | "Analyze the impact of...", "Evaluate whether...", multi-paragraph prompts, explicit request for depth/rigor, research-grade questions, contested topics |
 
-   **Default is `"full"`.** When uncertain, tier up. The cost of running extra layers on a simple query is wasted money (~$30); the cost of running too few layers on a complex query is a bad report.
+   **Default is `"full"`.** When uncertain, tier up. Running the full pipeline on a simple query wastes money; running the light pipeline on a complex query produces a bad report.
 
    **`response_format`** — how the output is shaped:
 
@@ -120,8 +119,7 @@ Read both before starting. The vault_tag is in the scaffold's "Run config" secti
 
    **The two dimensions are independent.** Most common pairings:
    - `light` + `short` — factual lookup, definition, simple how-to
-   - `light` + `structured` — list/catalog, quick multi-entity comparison
-   - `standard` + `structured` — survey, landscape overview, decision matrix
+   - `light` + `structured` — list/catalog, quick multi-entity comparison, landscape overview
    - `full` + `argumentative` — deep analysis, literature review, forecast (the current default)
    - `full` + `structured` — comprehensive survey where adversarial depth still matters
 

--- a/src/hyperresearch/skills/hyperresearch-10-triple-draft.md
+++ b/src/hyperresearch/skills/hyperresearch-10-triple-draft.md
@@ -13,9 +13,9 @@ description: >
 
 # Step 10 — Triple-draft ensemble (curated lists, parallel writers)
 
-**⚠ CRITICAL ANTI-PATTERN: Writing a single draft for `standard` or `full` tier is a PIPELINE VIOLATION.** In V7 runs, context compaction caused the orchestrator to forget this step's procedure and write a single draft instead of spawning 3 sub-orchestrators. V8 fixes this by loading this skill fresh at the moment it's needed. **If you find yourself about to write `research/notes/final_report.md` directly without spawning 3 `hyperresearch-draft-orchestrator` subagents, STOP. Re-read this skill. Spawn the sub-orchestrators.** (Light tier is the ONE exception — see "Light tier" section below.)
+**⚠ CRITICAL ANTI-PATTERN: Writing a single draft for `full` tier is a PIPELINE VIOLATION.** In V7 runs, context compaction caused the orchestrator to forget this step's procedure and write a single draft instead of spawning 3 sub-orchestrators. V8 fixes this by loading this skill fresh at the moment it's needed. **If you find yourself about to write `research/notes/final_report.md` directly without spawning 3 `hyperresearch-draft-orchestrator` subagents, STOP. Re-read this skill. Spawn the sub-orchestrators.** (Light tier is the ONE exception — see "Light tier" section below.)
 
-**Tier gate:** Runs for ALL tiers. For `light` tier: write a single draft directly to `research/notes/final_report.md` and skip ahead to step 15 (polish). For `standard` and `full`: run the triple-draft ensemble below — step 11 (synthesizer) will turn the 3 drafts into the final report.
+**Tier gate:** Runs for ALL tiers. For `light` tier: write a single draft directly to `research/notes/final_report.md` and skip ahead to step 15 (polish). For `full`: run the triple-draft ensemble below — step 11 (synthesizer) will turn the 3 drafts into the final report.
 
 **Goal:** produce THREE independent angle-specific drafts (`draft-{a,b,c}.md`). Step 11 (synthesizer subagent) consumes all three and writes the final report.
 
@@ -26,7 +26,7 @@ description: >
 Read these inputs:
 - `research/scaffold.md` — vault_tag, modality, wrapper requirements
 - `research/prompt-decomposition.json` — atomic items, required_section_headings, response_format, citation_style, pipeline_tier
-- `research/temp/evidence-digest.md` — top claims + verbatim quotes — PRIMARY EVIDENCE LAYER (standard / full only; absent for light)
+- `research/temp/evidence-digest.md` — top claims + verbatim quotes — PRIMARY EVIDENCE LAYER (full only; absent for light)
 - `research/comparisons.md` (full tier) — cross-locus tensions
 - `research/temp/source-tensions.json` (full tier) — expert disagreements
 - `research/temp/coverage-gaps.md` (if exists) — items with weak source coverage
@@ -74,7 +74,7 @@ If `pipeline_tier == "light"`: SKIP step 10.1 — 10.3 below and follow this sec
 
 ---
 
-## Step 10.1 — Define 3 analytical angles (standard / full tier)
+## Step 10.1 — Define 3 analytical angles (full tier)
 
 Based on the evidence, tensions, and query, assign each sub-orchestrator a distinct angle. The angles should produce genuinely different drafts — not three versions of the same argument.
 
@@ -212,4 +212,4 @@ When all 3 sub-orchestrators return:
 Return to the entry skill (`hyperresearch`). Tier-based routing:
 
 - **light tier:** You already wrote `research/notes/final_report.md` directly. Skip steps 11-14 (no synthesis, no critics, no patcher) and invoke `Skill(skill: "hyperresearch-15-polish")`.
-- **standard / full tier:** Invoke `Skill(skill: "hyperresearch-11-synthesize")`.
+- **full tier:** Invoke `Skill(skill: "hyperresearch-11-synthesize")`.

--- a/src/hyperresearch/skills/hyperresearch-11-synthesize.md
+++ b/src/hyperresearch/skills/hyperresearch-11-synthesize.md
@@ -7,12 +7,12 @@ description: >
   tool-locked) that writes the final report in TWO passes — pass 1 rough
   integrated draft, pass 2 voice/redundancy/length cleanup. Skipped for
   light tier (which writes a single draft directly in step 10). Invoked
-  via Skill tool from the entry skill (standard / full tiers).
+  via Skill tool from the entry skill (full tier).
 ---
 
 # Step 11 — Synthesize the final report
 
-**Tier gate:** SKIP entirely for `light` tier — light tier wrote `research/notes/final_report.md` directly in step 10 and proceeds straight to step 15 (polish). For `standard` and `full`: run as documented below.
+**Tier gate:** SKIP entirely for `light` tier — light tier wrote `research/notes/final_report.md` directly in step 10 and proceeds straight to step 15 (polish). For `full`: run as documented below.
 
 **Goal:** turn the 3 angle-specific drafts from step 10 into ONE integrated final report at `research/notes/final_report.md`. The orchestrator preps the strategic brief; the synthesizer subagent writes the report in two passes (rough integrated draft, then voice/redundancy/length cleanup).
 

--- a/src/hyperresearch/skills/hyperresearch-12-critics.md
+++ b/src/hyperresearch/skills/hyperresearch-12-critics.md
@@ -1,17 +1,16 @@
 ---
 name: hyperresearch-12-critics
 description: >
-  Step 12 of the hyperresearch V8 pipeline. Spawns 4 adversarial critics in
-  parallel against the synthesized final report from step 11 (full tier)
-  or 2 critics (standard tier). Each critic produces an independent
-  findings JSON that the patcher (step 14) consumes. Critics never
-  modify the draft directly. Invoked via Skill tool from the entry skill
-  (standard / full tiers).
+  Step 12 of the hyperresearch V8 pipeline. Spawns 4 adversarial critics
+  in parallel against the synthesized final report from step 11. Each
+  critic produces an independent findings JSON that the patcher (step 14)
+  consumes. Critics never modify the draft directly. Invoked via Skill
+  tool from the entry skill (full tier only).
 ---
 
 # Step 12 — Adversarial critique (parallel critics)
 
-**Tier gate:** SKIP entirely for `light` tier — proceed directly to step 15 (polish). For `standard` tier: spawn only **2 critics** — `width-critic` and `instruction-critic`. For `full` tier: spawn all 4.
+**Tier gate:** SKIP entirely for `light` tier — proceed directly to step 15 (polish). For `full` tier: spawn all 4 critics.
 
 **Goal:** independent findings lists against the synthesized final report, each from a different adversarial angle. Critics complement rather than duplicate.
 
@@ -29,17 +28,11 @@ Read these inputs:
 
 ## Procedure
 
-1. **Spawn critics in parallel.** In ONE message, invoke the right number of critics for the tier:
-
-   **Full tier — all 4 critics:**
+1. **Spawn all 4 critics in parallel.** In ONE message:
    - `hyperresearch-dialectic-critic` → `research/critic-findings-dialectic.json` (counter-evidence the draft missed or straw-manned)
    - `hyperresearch-depth-critic` → `research/critic-findings-depth.json` (shallow spots where interim notes could fill substance)
    - `hyperresearch-width-critic` → `research/critic-findings-width.json` (corpus clusters the draft ignores despite evidence)
    - `hyperresearch-instruction-critic` → `research/critic-findings-instruction.json` (atomic items from the decomposition that the draft missed, under-covered, reordered, or reformatted)
-
-   **Standard tier — 2 critics only:**
-   - `hyperresearch-width-critic` → `research/critic-findings-width.json`
-   - `hyperresearch-instruction-critic` → `research/critic-findings-instruction.json`
 
 2. **Pass each critic** (standard 3-piece contract):
    ```
@@ -70,9 +63,8 @@ Read these inputs:
 
 ## Exit criterion
 
-- All required critic findings JSONs exist (`research/critic-findings-<name>.json`)
+- All 4 critic findings JSONs exist (`research/critic-findings-<name>.json`)
 - Each is valid JSON with a `findings` array
-- For full tier: 4 files. For standard: 2 files (width + instruction).
 
 ---
 

--- a/src/hyperresearch/skills/hyperresearch-13-gap-fetch.md
+++ b/src/hyperresearch/skills/hyperresearch-13-gap-fetch.md
@@ -6,12 +6,12 @@ description: >
   topic X" and the vault has zero sources on X, the patcher has nothing
   to cite. This step fetches the missing sources BEFORE patching so the
   patcher has ammunition. Capped at 5 gaps. Invoked via Skill tool from
-  the entry skill (standard / full tiers).
+  the entry skill (full tier).
 ---
 
 # Step 13 — Post-critic gap fetch (conditional)
 
-**Tier gate:** Run for `standard` and `full`. Skip for `light` (no critics = no findings).
+**Tier gate:** Run for `full`. Skip for `light` (no critics = no findings).
 
 **Goal:** critics identify gaps the draft missed, but the patcher can only work with evidence already in the vault. If a critic says "the draft ignored topic X" and the vault has zero sources on X, the patcher has nothing to cite. This step fills those gaps BEFORE patching.
 

--- a/src/hyperresearch/skills/hyperresearch-14-patcher.md
+++ b/src/hyperresearch/skills/hyperresearch-14-patcher.md
@@ -6,12 +6,12 @@ description: >
   surgical Edit hunks against the synthesized final report. Zero
   regeneration. Pre-stubs the patch log because Edit cannot create files.
   Handles orchestrator-escalated structural restructures inline. Invoked
-  via Skill tool from the entry skill (standard / full tiers).
+  via Skill tool from the entry skill (full tier).
 ---
 
 # Step 14 — Patch pass
 
-**Tier gate:** SKIP entirely for `light` tier (no critics = no findings to patch). For `standard` and `full`: run as documented.
+**Tier gate:** SKIP entirely for `light` tier (no critics = no findings to patch). For `full`: run as documented.
 
 **Goal:** apply critic findings to the draft as surgical Edit hunks. Zero regeneration.
 

--- a/src/hyperresearch/skills/hyperresearch-15-polish.md
+++ b/src/hyperresearch/skills/hyperresearch-15-polish.md
@@ -86,7 +86,6 @@ If the escalation names a structural issue (e.g., "user asked for a ranked list;
 Before declaring the run complete, verify every expected pipeline artifact exists. **The required set depends on the tier:**
 
 - **light tier:** only `research/polish-log.json` is required (steps 12–14 are skipped, so no critic findings or patch log).
-- **standard tier:** require `research/critic-findings-width.json`, `research/critic-findings-instruction.json`, `research/patch-log.json`, `research/polish-log.json` (depth and dialectic critics did not run).
 - **full tier:** require all four critic findings + patch-log + polish-log:
 
 ```bash

--- a/src/hyperresearch/skills/hyperresearch-2-width-sweep.md
+++ b/src/hyperresearch/skills/hyperresearch-2-width-sweep.md
@@ -4,14 +4,14 @@ description: >
   Step 2 of the hyperresearch V8 pipeline. Multi-perspective search planning
   (breadth / depth / adversarial lenses) followed by parallel fetcher waves.
   Achieves comprehensive topical coverage with 40-100 curated sources for
-  standard/full tiers. Includes coverage check, evidence redundancy audit,
+  full tier. Includes coverage check, evidence redundancy audit,
   and source count gating. Invoked via Skill tool from the entry skill
   after step 1 completes.
 ---
 
 # Step 2 — Width sweep
 
-**Tier gate:** Runs for ALL tiers. For `light` tier: skip academic APIs, target 12–20 sources, limit to 2–3 fetcher batches. For `standard` and `full`: run the full procedure below.
+**Tier gate:** Runs for ALL tiers. For `light` tier: skip academic APIs, target 12–20 sources, limit to 2–3 fetcher batches. For `full`: run the full procedure below.
 
 **Goal:** achieve comprehensive topical coverage — every atomic item from the decomposition must have at least 3 supporting sources by the end of this step. Target 40–80 curated sources for `full` tier.
 
@@ -94,9 +94,9 @@ Before spawning any fetchers, produce a **search plan** that maps the decomposit
 
 1. **Academic APIs first.** For topics with a research literature, hit Semantic Scholar / arXiv / OpenAlex / PubMed BEFORE web search. Academic APIs return citation-ranked canonical papers.
 
-2. **Web searches from the plan.** Execute ALL planned searches across all three lenses. Aim for **80–120 candidate URLs** before deduplication for `full` tier, 60–100 for `standard`.
+2. **Web searches from the plan.** Execute ALL planned searches across all three lenses. Aim for **80–120 candidate URLs** before deduplication for `full` tier.
 
-3. **Build and deduplicate the master URL queue.** Remove exact-URL duplicates. Remove obvious junk domains. The deduplicated queue should have **60–100 URLs** for `full` tier, 50–80 for `standard`.
+3. **Build and deduplicate the master URL queue.** Remove exact-URL duplicates. Remove obvious junk domains. The deduplicated queue should have **60–100 URLs** for `full` tier.
 
    **Wikipedia SOURCE HUB rule:** Include Wikipedia URLs in the queue — they're valuable for discovery — but treat them as SOURCE HUBS, not as citable sources. When a fetcher processes a Wikipedia article, it extracts the references/citations Wikipedia links to. Those primary sources go into Wave 2 (or the same wave if capacity permits). Wikipedia itself is NEVER cited in the final report.
 
@@ -106,7 +106,7 @@ Before spawning any fetchers, produce a **search plan** that maps the decomposit
 
 ## Step 2.3 — Utility scoring and selection
 
-**Tier gate:** SKIP for `light`. Run for `standard` and `full`.
+**Tier gate:** SKIP for `light`. Run for `full`.
 
 Before batching URLs, score each candidate URL on six dimensions (0–3 each, max composite 18):
 
@@ -199,7 +199,7 @@ After Wave 1 returns, run the coverage check before proceeding:
 
 ## Step 2.6 — Evidence redundancy audit
 
-**Tier gate:** SKIP for `light`. Run for `standard` and `full`.
+**Tier gate:** SKIP for `light`. Run for `full`.
 
 **Goal:** detect when N sources are really 1 source in N outfits.
 
@@ -222,7 +222,6 @@ After Wave 1 returns, run the coverage check before proceeding:
 | Tier | Minimum sources | Target sources | Fetchers per wave | Waves |
 |------|----------------|---------------|-------------------|-------|
 | `light` | 10 | 15–25 | 3–5 | 1–2 |
-| `standard` | 30 | 40–70 | 8–10 | 2 |
 | `full` | 45 | 55–80 | 8–12 | 2–3 |
 
 Substantive (non-deprecated) note counts. Quality over quantity — reference reports average ~65 sources. Beyond ~80, each additional source yields diminishing returns while degrading summarizer quality.
@@ -277,4 +276,4 @@ If you fall short after two waves, proceed anyway but ensure `coverage-gaps.md` 
 Return to the entry skill (`hyperresearch`). Tier-based routing:
 
 - **light tier:** Skip directly to step 10 — invoke `Skill(skill: "hyperresearch-10-triple-draft")` (light tier writes a single draft, not the ensemble)
-- **standard / full tier:** Invoke `Skill(skill: "hyperresearch-3-contradiction-graph")`
+- **full tier:** Invoke `Skill(skill: "hyperresearch-3-contradiction-graph")`

--- a/src/hyperresearch/skills/hyperresearch-3-contradiction-graph.md
+++ b/src/hyperresearch/skills/hyperresearch-3-contradiction-graph.md
@@ -11,7 +11,7 @@ description: >
 
 # Step 3 — Contradiction graph
 
-**Tier gate:** SKIP for `light`. Run for `standard` and `full`.
+**Tier gate:** SKIP for `light`. Run for `full`.
 
 **Goal:** before loci analysis, build an explicit graph of opposing claims. Loci should emerge from where the evidence actually forks, not from agent intuition about what seems interesting.
 
@@ -70,5 +70,4 @@ If no claims files exist (e.g., fetchers didn't produce them), skip this step en
 
 Return to the entry skill (`hyperresearch`). Tier-based routing:
 
-- **standard tier:** Skip steps 4–8. Invoke `Skill(skill: "hyperresearch-9-evidence-digest")`
 - **full tier:** Invoke `Skill(skill: "hyperresearch-4-loci-analysis")`

--- a/src/hyperresearch/skills/hyperresearch-4-loci-analysis.md
+++ b/src/hyperresearch/skills/hyperresearch-4-loci-analysis.md
@@ -11,7 +11,7 @@ description: >
 
 # Step 4 — Loci analysis (parallel, 2 analysts)
 
-**Tier gate:** SKIP entirely for `light` and `standard` tiers — proceed directly to step 9. Only `full` tier runs loci analysis.
+**Tier gate:** SKIP entirely for `light` tier — proceed directly to step 9. Only `full` tier runs loci analysis.
 
 **Goal:** identify 1–6 specific questions where depth investigation will pay off.
 

--- a/src/hyperresearch/skills/hyperresearch-5-depth-investigation.md
+++ b/src/hyperresearch/skills/hyperresearch-5-depth-investigation.md
@@ -11,7 +11,7 @@ description: >
 
 # Step 5 — Depth investigation (parallel, K = len(loci))
 
-**Tier gate:** SKIP entirely for `light` and `standard` tiers. Only `full` tier runs depth investigation.
+**Tier gate:** SKIP entirely for `light` tier. Only `full` tier runs depth investigation.
 
 **Goal:** produce ONE `interim-{locus}.md` note per locus with dense synthesis that the draft sub-orchestrators (step 10) will draft from.
 

--- a/src/hyperresearch/skills/hyperresearch-6-cross-locus-reconcile.md
+++ b/src/hyperresearch/skills/hyperresearch-6-cross-locus-reconcile.md
@@ -10,7 +10,7 @@ description: >
 
 # Step 6 — Cross-locus reconciliation
 
-**Tier gate:** SKIP entirely for `light` and `standard` tiers (no loci = no comparisons). Only `full` tier runs this step.
+**Tier gate:** SKIP entirely for `light` tier (no loci = no comparisons). Only `full` tier runs this step.
 
 **Goal:** before drafting, reconcile the committed positions from all depth investigators. Produce `research/comparisons.md` — a short document naming 3–5 places where the loci conflict or complicate each other.
 

--- a/src/hyperresearch/skills/hyperresearch-7-source-tensions.md
+++ b/src/hyperresearch/skills/hyperresearch-7-source-tensions.md
@@ -12,7 +12,7 @@ description: >
 
 # Step 7 — Source tension extraction
 
-**Tier gate:** SKIP for `light` and `standard` tiers. Only `full` tier runs this step.
+**Tier gate:** SKIP for `light` tier. Only `full` tier runs this step.
 
 **Goal:** extract explicit expert disagreements from the corpus and comparisons into a structured artifact that step 10 MUST include as a dedicated section. This is the single highest-leverage move for the insight dimension.
 

--- a/src/hyperresearch/skills/hyperresearch-8-corpus-critic.md
+++ b/src/hyperresearch/skills/hyperresearch-8-corpus-critic.md
@@ -11,7 +11,7 @@ description: >
 
 # Step 8 — Pre-draft corpus critic (targeted gap-fill)
 
-**Tier gate:** `full` tier ONLY. Skip for `light` and `standard`.
+**Tier gate:** `full` tier ONLY. Skip for `light`.
 
 **Goal:** before drafting, ask "what source, if found, would overturn the current direction?" and run a targeted fetch wave to fill the most dangerous gaps. This is the highest-leverage intervention point in the pipeline — corrections applied before drafting cost nothing; corrections applied after drafting require patches and risk structural drift.
 

--- a/src/hyperresearch/skills/hyperresearch-9-evidence-digest.md
+++ b/src/hyperresearch/skills/hyperresearch-9-evidence-digest.md
@@ -6,12 +6,12 @@ description: >
   research/temp/evidence-digest.md — a single high-fidelity evidence
   index the draft sub-orchestrators read as primary evidence (higher
   fidelity than fetcher summaries). Invoked via Skill tool from the
-  entry skill (standard / full tiers).
+  entry skill (full tier).
 ---
 
 # Step 9 — Evidence digest
 
-**Tier gate:** Run for `standard` and `full`. Skip for `light`.
+**Tier gate:** Run for `full`. Skip for `light`.
 
 **Goal:** assemble the top load-bearing claims and verbatim quotes from the claims JSONs into a single digest file the drafter reads as primary evidence — higher-fidelity than fetcher summaries.
 
@@ -32,9 +32,7 @@ Read these inputs:
 
 1. **Read all claims files** from `research/temp/claims-*.json` for every non-deprecated note tagged with the vault tag. If no claim files exist (e.g., fetchers didn't produce them), skip this step.
 
-2. **Filter and rank.** Keep claims where `confidence` is `"high"` OR `evidence_type` is `"empirical"` or `"statistical"`. From the remainder, prefer claims with non-empty `numbers` arrays and non-empty `quoted_support`. Cap at:
-   - **80–120 claims total** for `full` tier
-   - **40–60 claims** for `standard` tier
+2. **Filter and rank.** Keep claims where `confidence` is `"high"` OR `evidence_type` is `"empirical"` or `"statistical"`. From the remainder, prefer claims with non-empty `numbers` arrays and non-empty `quoted_support`. Cap at **80–120 claims total** for `full` tier.
 
 3. **Group by atomic item.** Match each surviving claim to the atomic item it is most relevant to based on **topic overlap** — do not rely on exact field matching. A claim about "United Health Group regulatory exposure" serves the atomic item "UNH risk factors" even though no field matches exactly. Use the claim's `entities`, `stance_target`, `scope_conditions`, and `claim` text holistically to judge relevance. When uncertain, include the claim under the most relevant item rather than dropping it to Ungrouped. Claims that genuinely don't map to any atomic item go into an "Ungrouped" section at the end.
 
@@ -67,9 +65,7 @@ Read these inputs:
 ## Exit criterion
 
 - `research/temp/evidence-digest.md` exists
-- Contains at least:
-  - 30 claims for `full` tier
-  - 15 claims for `standard` tier
+- Contains at least 30 claims for `full` tier
 - Grouped by atomic item with verbatim quoted_support and source_note_id
 
 If fewer claims exist in total, include all of them.
@@ -84,4 +80,4 @@ Return to the entry skill (`hyperresearch`). Invoke step 10:
 Skill(skill: "hyperresearch-10-triple-draft")
 ```
 
-Step 10 is the most important step in the pipeline. Re-read the entry skill before invoking if needed — the triple-draft ensemble must spawn 3 draft-orchestrators for `standard` and `full` tiers.
+Step 10 is the most important step in the pipeline. Re-read the entry skill before invoking if needed — the triple-draft ensemble must spawn 3 draft-orchestrators for `full` tier.

--- a/src/hyperresearch/skills/hyperresearch.md
+++ b/src/hyperresearch/skills/hyperresearch.md
@@ -2,15 +2,12 @@
 name: hyperresearch
 description: >
   Deep research via the HYPERRESEARCH V8 architecture — a tier-adaptive 16-step
-  pipeline (light / standard / full) that scales from a 3-minute $5 answer
-  to a 55-minute $60 adversarially-audited report. This entry skill is a
-  ROUTER. It does not contain step procedures — it tells you which Skill to
-  invoke for each step, in order. Each step's instructions live in its own
-  skill file (`hyperresearch-1-decompose` through `hyperresearch-16-readability-audit`) and
-  are loaded fresh into context when you invoke them. This solves the
-  context-compaction problem that V7 hit: instead of one 1200-line skill
-  that gets evicted by Layer 4, each step is a focused 50-150 line skill
-  that lands in context only when needed.
+  pipeline (light / full) that scales from a ~30-minute light-tier answer to
+  a 1.5–2.5 hour adversarially-audited report. This entry skill is a ROUTER.
+  It does not contain step procedures — it tells you which Skill to invoke
+  for each step, in order. Each step's instructions live in its own skill
+  file (`hyperresearch-1-decompose` through `hyperresearch-16-readability-audit`)
+  and are loaded fresh into context when you invoke them.
 ---
 
 # Hyperresearch V8 — multi-skill chain orchestrator
@@ -43,18 +40,18 @@ When you invoke a Skill, that skill's full procedure is loaded into your context
 |---|---|---|---|
 | 1 | `hyperresearch-1-decompose` | Canonical query → scaffold + decomposition + coverage matrix + tier classification | all |
 | 2 | `hyperresearch-2-width-sweep` | Multi-perspective search plan + parallel fetcher waves | all |
-| 3 | `hyperresearch-3-contradiction-graph` | Pair contradictions across the corpus into ranked fight clusters | std/full |
+| 3 | `hyperresearch-3-contradiction-graph` | Pair contradictions across the corpus into ranked fight clusters | full |
 | 4 | `hyperresearch-4-loci-analysis` | 2 loci-analysts → scored loci.json with source budgets | full |
 | 5 | `hyperresearch-5-depth-investigation` | K depth-investigators in parallel → interim notes with committed positions | full |
 | 6 | `hyperresearch-6-cross-locus-reconcile` | Reconcile committed positions → comparisons.md | full |
 | 7 | `hyperresearch-7-source-tensions` | Extract expert disagreements → source-tensions.json | full |
 | 8 | `hyperresearch-8-corpus-critic` | "What source would overturn this?" + targeted gap-fill fetch | full |
-| 9 | `hyperresearch-9-evidence-digest` | Top claims + verbatim quotes → evidence-digest.md | std/full |
+| 9 | `hyperresearch-9-evidence-digest` | Top claims + verbatim quotes → evidence-digest.md | full |
 | 10 | `hyperresearch-10-triple-draft` | Per-angle source curation + 3 parallel draft-orchestrators (3 angle-specific drafts) | all |
-| 11 | `hyperresearch-11-synthesize` | Synthesis plan + outline + spawn synthesizer subagent (two-pass write) → final_report.md | std/full |
-| 12 | `hyperresearch-12-critics` | 4 adversarial critics in parallel → findings JSONs | std/full |
-| 13 | `hyperresearch-13-gap-fetch` | Fetch sources for critic-identified vault gaps | std/full |
-| 14 | `hyperresearch-14-patcher` | Surgical Edit hunks applied to draft | std/full |
+| 11 | `hyperresearch-11-synthesize` | Synthesis plan + outline + spawn synthesizer subagent (two-pass write) → final_report.md | full |
+| 12 | `hyperresearch-12-critics` | 4 adversarial critics in parallel → findings JSONs | full |
+| 13 | `hyperresearch-13-gap-fetch` | Fetch sources for critic-identified vault gaps | full |
+| 14 | `hyperresearch-14-patcher` | Surgical Edit hunks applied to draft | full |
 | 15 | `hyperresearch-15-polish` | Hygiene + filler pass (Edit-based subagent) | all |
 | 16 | `hyperresearch-16-readability-audit` | Readability recommender writes JSON suggestions; orchestrator selectively applies via Edit | all |
 
@@ -62,15 +59,14 @@ When you invoke a Skill, that skill's full procedure is loaded into your context
 
 ## Tier routing
 
-Step 1 classifies the query into a `pipeline_tier` (`light` / `standard` / `full`). The tier is written to `research/prompt-decomposition.json`. After step 1, **read that file** to learn the tier, then sequence steps according to:
+Step 1 classifies the query into a `pipeline_tier` (`light` / `full`). The tier is written to `research/prompt-decomposition.json`. After step 1, **read that file** to learn the tier, then sequence steps according to:
 
 | Tier | Steps that run | Typical cost | Typical time |
 |------|---|---|---|
-| `light` | 1 → 2 → 10 (single draft) → 15 → 16 | ~$3–8 | ~3–8 min |
-| `standard` | 1 → 2 → 3 → 9 → 10 → 11 → 12 → 13 → 14 → 15 → 16 | ~$10–22 | ~10–22 min |
-| `full` | 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → 11 → 12 → 13 → 14 → 15 → 16 | ~$35–65 | ~25–60 min |
+| `light` | 1 → 2 → 10 (single draft) → 15 → 16 | ~$5–15 | ~30–40 min |
+| `full` | 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → 11 → 12 → 13 → 14 → 15 → 16 | ~$60–120 | ~1.5–2.5 hours |
 
-**RESPECT THE TIER GATE.** When step 1 classifies a query as `light` or `standard`, do NOT run the skipped steps "just to be thorough." The tier classification is a product decision: simple queries should produce fast, cheap, right-sized answers. Trust the classification. If you're uncertain, tier up — but never silently upgrade every query to `full`.
+**RESPECT THE TIER GATE.** When step 1 classifies a query as `light`, do NOT run the skipped steps "just to be thorough." The tier classification is a product decision: simple queries should produce fast, right-sized answers. Trust the classification. If you're uncertain, tier up — but never silently upgrade every query to `full`.
 
 ---
 
@@ -104,7 +100,7 @@ Before you invoke any step skill, do this:
    - **compare**: proportionate per-entity depth + a committed recommendation
    - **forecast**: predictive claims grounded in past + present, explicit time horizon
 
-5. **Write the scaffold.** Write `research/scaffold.md` with the same template `/research` uses (see `.claude/skills/hyperresearch/SKILL.md` Step 7). The scaffold is your private planning document — it MUST NOT appear anywhere in the final report. Include in scaffold:
+5. **Write the scaffold.** Write `research/scaffold.md` (your private planning document — it MUST NOT appear anywhere in the final report). Include in scaffold:
    - User Prompt (VERBATIM — gospel)
    - Run config (vault_tag, query_file_path, modality, wrapper requirements)
    - Modality classification rationale
@@ -194,7 +190,7 @@ for f in research/critic-findings-dialectic.json \
 done
 ```
 
-(Skip critic-findings-{dialectic,depth} if standard tier — only width + instruction critics ran.)
+(Light tier skips critics + patcher entirely — the critic-findings and patch-log files won't exist. That's expected; only `polish-log.json` is required for light.)
 
 Then run lint:
 ```bash
@@ -218,9 +214,9 @@ If any rule returns `error` severity issues, address them before declaring compl
 6. **Steps are sequential at the outermost level, parallel within.** You cannot start step N+1 before step N completes. Within a step, parallelism is mandatory when there are multiple subagents.
 7. **Canonical research query is gospel everywhere.** Every subagent gets the verbatim query.
 8. **Hygiene rules apply to the final report only.** Workspace artifacts (scaffold, loci JSONs, interim notes, comparisons.md, patch log) can look however they need to look.
-9. **NEVER skip a step that the tier gate says to run.** For `full` tier, ALL 16 steps run. For `standard`, the prescribed 11 steps run. For `light`, the prescribed 5 steps run.
-10. **Step 10 triple-draft ensemble is MANDATORY for `standard` and `full` tiers.** You MUST spawn 3 `hyperresearch-draft-orchestrator` subagents. Writing `research/notes/final_report.md` directly in step 10 (instead of going through the synthesizer in step 11) is a PIPELINE VIOLATION for these tiers.
-11. **Step 11 synthesis is MANDATORY for `standard` and `full` tiers.** The synthesizer subagent (Read+Write tool-locked) writes the final report from the 3 drafts. The orchestrator does NOT write the final report itself for these tiers.
+9. **NEVER skip a step that the tier gate says to run.** For `full` tier, ALL 16 steps run. For `light`, the prescribed 5 steps run.
+10. **Step 10 triple-draft ensemble is MANDATORY for `full` tier.** You MUST spawn 3 `hyperresearch-draft-orchestrator` subagents. Writing `research/notes/final_report.md` directly in step 10 (instead of going through the synthesizer in step 11) is a PIPELINE VIOLATION for these tiers.
+11. **Step 11 synthesis is MANDATORY for `full` tier.** The synthesizer subagent (Read+Write tool-locked) writes the final report from the 3 drafts. The orchestrator does NOT write the final report itself for these tiers.
 12. **Subagents read full source text.** Draft sub-orchestrators MUST batch-read every note in their `must_read_note_ids` list before writing. Fetchers MUST chase 3-8 primary sources via citation chains.
 13. **NEVER emit a bare text response while subagent tasks are in flight.**
 

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -21,33 +21,27 @@ from hyperresearch.core.hooks import (
 )
 
 # ---------------------------------------------------------------------------
-# Entry skill — installs at both /hyperresearch and /research
+# Entry skill — installs at /hyperresearch only (v0.8.1+)
 # ---------------------------------------------------------------------------
 
 
-def test_install_hyperresearch_skill_creates_both_aliases(tmp_vault):
-    """The entry skill installs at .claude/skills/hyperresearch/SKILL.md and
-    .claude/skills/research/SKILL.md so Claude Code registers BOTH
-    `/hyperresearch` and `/research` as slash-command triggers. Same content,
-    different `name:` frontmatter.
+def test_install_hyperresearch_skill_creates_skill_dir(tmp_vault):
+    """The entry skill installs at .claude/skills/hyperresearch/SKILL.md so
+    Claude Code registers `/hyperresearch` as the slash-command trigger.
+    The /research alias was retired in v0.8.1 — only /hyperresearch now.
     """
     result = _install_hyperresearch_skill(tmp_vault.root)
     assert result is not None
 
     hyper_path = tmp_vault.root / ".claude" / "skills" / "hyperresearch" / "SKILL.md"
-    research_path = tmp_vault.root / ".claude" / "skills" / "research" / "SKILL.md"
     assert hyper_path.exists()
-    assert research_path.exists()
+
+    # /research dir must NOT be created
+    research_path = tmp_vault.root / ".claude" / "skills" / "research" / "SKILL.md"
+    assert not research_path.exists()
 
     hyper_body = hyper_path.read_text(encoding="utf-8")
-    research_body = research_path.read_text(encoding="utf-8")
     assert "name: hyperresearch" in hyper_body
-    assert "name: research" in research_body
-    # Body content (everything after the name line) is identical
-    assert hyper_body.replace("name: hyperresearch", "") == research_body.replace(
-        "name: research", ""
-    )
-
     # Entry skill is the chain router — must reference step skills
     assert "hyperresearch-1-decompose" in hyper_body
     assert "hyperresearch-10-triple-draft" in hyper_body
@@ -382,9 +376,10 @@ def test_install_hooks_registers_full_hyperresearch_roster(tmp_vault):
         f"missing: {expected_agents - actual_agents}, extra: {actual_agents - expected_agents}"
     )
 
-    # Both entry-skill aliases registered (/hyperresearch and /research)
+    # Entry skill registered as /hyperresearch (the /research alias was
+    # retired in v0.8.1)
     assert (tmp_vault.root / ".claude" / "skills" / "hyperresearch" / "SKILL.md").exists()
-    assert (tmp_vault.root / ".claude" / "skills" / "research" / "SKILL.md").exists()
+    assert not (tmp_vault.root / ".claude" / "skills" / "research" / "SKILL.md").exists()
 
     # Hook settings written
     assert (tmp_vault.root / ".claude" / "settings.json").exists()


### PR DESCRIPTION
## Summary

Surface cleanup based on real-run feedback:

- **`/research` alias retired.** Only `/hyperresearch` remains. The `research` skill dir is added to `_RETIRED_SKILL_DIRS` so existing installs prune it automatically on the next `hyperresearch install`.
- **`standard` tier removed.** Only `light` and `full` remain. Step 1's classifier folds the previous standard-tier signals (surveys, multi-entity comparisons, landscape overviews) into `light`. Mid-tier fan-out (3 critics, 60-100 URLs, 40-60 claims) is gone — the simplification is intentional.
- **Time estimates re-calibrated.** Light: ~30-40 min (was 3-8 min). Full: ~1.5-2.5 hours (was 25-60 min). Numbers reflect realistic wall-clock times observed across recent runs.
- **README tier table** drops the cost column per request.
- **Version bumped** 0.8.0 → 0.8.1.

## Files touched

- `pyproject.toml` + `src/hyperresearch/__init__.py` — version bump
- `src/hyperresearch/core/hooks.py` — single-alias install, `research` added to retired skill dirs
- All 16 step skills — strip `standard`-tier branches and `std/full` tier-gate strings
- `src/hyperresearch/skills/hyperresearch.md` — entry skill: routing table loses standard row, description rewritten, integrity-gate parenthetical updated for light tier
- `src/hyperresearch/skills/hyperresearch-1-decompose.md` — classifier table loses standard row, signal words from standard absorbed into light
- `src/hyperresearch/core/agent_docs.py` — CLAUDE.md template rewritten
- `src/hyperresearch/cli/lint.py` — `extract-coverage` rule description updated
- `README.md` — tier table simplified to two rows, cost column dropped, time estimates updated
- `CHANGELOG.md` — v0.8.1 entry
- `tests/test_core/test_hooks.py` — single-alias assertions

## Test plan

- [x] `python -m ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 163 pass
- [x] `hyperresearch install` on this repo — pruned old `research/` skill dir, installed `/hyperresearch` only, all 16 step skills present
- [x] `hyperresearch --version` reports `0.8.1`

## Merge note

Squash-merge to land as a single `v0.8.1` commit on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)