### PR TITLE
ci: auto-publish to PyPI on git tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,12 @@
 name: Publish to PyPI
 
 on:
+  push:
+    tags:
+      - "v*"
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds tag-push and workflow_dispatch triggers to publish.yml so future version bumps are one tag push away from being on PyPI. Existing release-published trigger kept for backwards compat.

Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)