### PR TITLE
v0.8.4: docs polish + release plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.8.4] - 2026-04-29
+
+### Polish + release plumbing
+
+- **README install section** now leads with the per-project path. `hyperresearch install --global` is documented as a power-user footnote with the honest tradeoff (~15 lines of system-reminder cost in every CC session). Per-project install keeps unrelated CC sessions clean.
+- **Tightened install section** from 22 lines to 7 — single command, single usage line, single Python disclaimer.
+- **Subagent roster table** corrected: `hyperresearch-fetcher` runs on Sonnet (not Haiku), `hyperresearch-draft-orchestrator` runs on Opus (not Sonnet).
+- **CI**: `publish.yml` now triggers on git tag pushes (`v*`) and `workflow_dispatch` in addition to GitHub releases. Future versions auto-publish on `git push --tags`.
+
 ## [0.8.3] - 2026-04-29
 
 ### Quieter global install — step skills lazy-load per-project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hyperresearch"
-version = "0.8.3"
+version = "0.8.4"
 description = "Claude Code harness for disciplined, adversarially-audited deep research with full provenance."
 readme = "README.md"
 license = "MIT"

--- a/src/hyperresearch/__init__.py
+++ b/src/hyperresearch/__init__.py
@@ -1,3 +1,3 @@
 """Hyperresearch — agent-driven research knowledge base."""
 
-__version__ = "0.8.3"
+__version__ = "0.8.4"


### PR DESCRIPTION
## Summary

Version bump to 0.8.4. Bundles recent docs and CI changes since 0.8.3:

- README install section reorder (per-project lead, --global footnote)
- README tightening (22 → 7 lines)
- Subagent roster correction (fetcher Sonnet, draft-orchestrator Opus)
- publish.yml tag-push trigger

No code changes. The bump is to get the latest README onto PyPI and exercise the new tag-push publish trigger.

Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)