### PR TITLE
Add OpenCode compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,13 @@ draco-bench/
 # in src/hyperresearch/skills/ (skills) and src/hyperresearch/core/hooks.py
 # (agent templates).
 .claude/
+.opencode/
 CLAUDE.md
 AGENTS.md
 GEMINI.md
+
+# Keep the repository-level OpenCode guide tracked.
+!/AGENTS.md
 
 # Per-vault research output
 research/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ python3.12 -m venv .venv
 - `hyperresearch install --platform claude` should create only Claude Code docs/hooks/skills/agents.
 - `hyperresearch install --platform opencode` should create only OpenCode docs/plugins/skills/agents.
 - `hyperresearch install --platform both` should create both harness integrations.
-- Interactive setup asks separate yes/no questions for Claude Code and OpenCode platform selection.
+- Interactive setup uses a terminal checklist: Tab/arrow keys move, Space toggles Claude Code/OpenCode, Enter confirms.
 
 ## Fast verification loop
 Run these before claiming completion:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ python3.12 -m venv .venv
 - `hyperresearch install --platform claude` should create only Claude Code docs/hooks/skills/agents.
 - `hyperresearch install --platform opencode` should create only OpenCode docs/plugins/skills/agents.
 - `hyperresearch install --platform both` should create both harness integrations.
-- Interactive setup uses a comma-separated checklist (`1,2` by default) for platform selection.
+- Interactive setup asks separate yes/no questions for Claude Code and OpenCode platform selection.
 
 ## Fast verification loop
 Run these before claiming completion:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Hyperresearch — Agent Guide
+
+## Environment
+- Python support is `>=3.11,<3.14` (3.14 is not supported).
+- Use a local virtualenv for all commands:
+
+```bash
+python3.12 -m venv .venv
+.venv/bin/python -m pip install -e '.[dev]'
+```
+
+## Fast verification loop
+Run these before claiming completion:
+
+```bash
+.venv/bin/python -m pytest -q
+.venv/bin/ruff check src tests
+.venv/bin/mypy src
+```
+
+## Repo conventions
+- Keep markdown as source of truth; SQLite is derived cache.
+- Prefer small, surgical edits over broad rewrites.
+- Preserve CLI JSON compatibility (`--json` output paths are user-facing contracts).
+- Keep generated research artifacts out of `research/notes/` unless intentionally creating notes.
+
+## Key paths
+- CLI commands: `src/hyperresearch/cli/`
+- Core vault/indexing logic: `src/hyperresearch/core/`
+- Search: `src/hyperresearch/search/`
+- Models: `src/hyperresearch/models/`
+- Tests: `tests/`
+
+## Agent docs, hooks, and skills
+- Project agent docs are maintained in both `CLAUDE.md` and `AGENTS.md` by `inject_agent_docs`.
+- The research-reminder hook is installed into both `.claude/settings.json` and `.claude/settings.local.json`; the hook accepts Claude-style `tool_name` and OpenCode-style lowercase `tool` payloads.
+- An OpenCode-native plugin is installed at `.opencode/plugins/hyperresearch-reminder.js` and uses `tool.definition` / `tool.execute.before` hooks.
+- Pipeline skills and subagent definitions are installed under `.claude/` (OpenCode reads these through Claude-compat paths).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,5 @@ Run these before claiming completion:
 - Project agent docs are maintained in both `CLAUDE.md` and `AGENTS.md` by `inject_agent_docs`.
 - The research-reminder hook is installed into both `.claude/settings.json` and `.claude/settings.local.json`; the hook accepts Claude-style `tool_name` and OpenCode-style lowercase `tool` payloads.
 - An OpenCode-native plugin is installed at `.opencode/plugins/hyperresearch-reminder.js` and uses `tool.definition` / `tool.execute.before` hooks.
+- OpenCode-native agents are rendered under `.opencode/agents/` with concrete models resolved from active OpenCode config files; flat-rate providers win when they expose the same underlying model.
 - Pipeline skills and subagent definitions are installed under `.claude/` (OpenCode reads these through Claude-compat paths).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,12 @@ python3.12 -m venv .venv
 .venv/bin/python -m pip install -e '.[dev]'
 ```
 
+## Install platform behavior
+- `hyperresearch install --platform claude` should create only Claude Code docs/hooks/skills/agents.
+- `hyperresearch install --platform opencode` should create only OpenCode docs/plugins/skills/agents.
+- `hyperresearch install --platform both` should create both harness integrations.
+- Interactive setup uses a comma-separated checklist (`1,2` by default) for platform selection.
+
 ## Fast verification loop
 Run these before claiming completion:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install hyperresearch && hyperresearch install
 
 Then `/hyperresearch <anything>` in Claude Code or OpenCode.
 
-Install writes `CLAUDE.md` and `AGENTS.md`, plus a Claude-compatible `PreToolUse` reminder hook in `.claude/settings.json` / `.claude/settings.local.json` and an OpenCode-native plugin in `.opencode/plugins/hyperresearch-reminder.js`. OpenCode gets the same research-base nudge before web/search tools and blocks raw WebFetch for source pages.
+Install writes `CLAUDE.md` and `AGENTS.md`, plus a Claude-compatible `PreToolUse` reminder hook in `.claude/settings.json` / `.claude/settings.local.json` and an OpenCode-native plugin in `.opencode/plugins/hyperresearch-reminder.js`. It also renders OpenCode-native subagents in `.opencode/agents/` with concrete models resolved from the active OpenCode config; if the same model is available through a flat-rate provider, that provider is preferred. OpenCode gets the same research-base nudge before web/search tools and blocks raw WebFetch for source pages.
 
 > Python 3.11–3.13. (3.14 not yet supported — use `pyenv install 3.13`, `uv venv -p 3.13`, or `py -3.13 -m venv .venv`.)
 >

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-**Hyperresearch turns Claude Code into a deep research agent. and currently leads the DeepResearch-Bench RACE leaderboard (benchmarked internally).** A tier-adaptive 16-step pipeline produces adversarially-audited reports with full source provenance. Every fetched source lands in a persistent, searchable vault that compounds across sessions.
+**Hyperresearch turns Claude Code and OpenCode into a deep research agent and currently leads the DeepResearch-Bench RACE leaderboard (benchmarked internally).** A tier-adaptive 16-step pipeline produces adversarially-audited reports with full source provenance. Every fetched source lands in a persistent, searchable vault that compounds across sessions.
 
 <p align="center">
   <img src="assets/benchmark.png" alt="DeepResearch-Bench top-5 — hyperresearch leads the chart ahead of Grep Deep Research, Cellcog Max, nvidia-aiq, Gemini Deep Research, and OpenAI Deep Research" width="780">
@@ -28,7 +28,9 @@ cd your-project
 pip install hyperresearch && hyperresearch install
 ```
 
-Then `/hyperresearch <anything>` in Claude Code.
+Then `/hyperresearch <anything>` in Claude Code or OpenCode.
+
+Install writes `CLAUDE.md` and `AGENTS.md`, plus a Claude-compatible `PreToolUse` reminder hook in `.claude/settings.json` / `.claude/settings.local.json` and an OpenCode-native plugin in `.opencode/plugins/hyperresearch-reminder.js`. OpenCode gets the same research-base nudge before web/search tools and blocks raw WebFetch for source pages.
 
 > Python 3.11–3.13. (3.14 not yet supported — use `pyenv install 3.13`, `uv venv -p 3.13`, or `py -3.13 -m venv .venv`.)
 >
@@ -164,7 +166,7 @@ After the academic sweep, run web searches for context, news, non-academic angle
 ## Requirements
 
 - Python 3.11+
-- [Claude Code](https://claude.com/claude-code)
+- [Claude Code](https://claude.com/claude-code) or [OpenCode](https://opencode.ai/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ cd your-project
 pip install hyperresearch && hyperresearch install
 ```
 
-Interactive setup asks which harness integrations to install:
+Interactive setup asks which harness integrations to install, with separate yes/no prompts for Claude Code and OpenCode:
 
 - Claude Code (`CLAUDE.md`, `.claude/settings*`, `.claude/skills`, `.claude/agents`)
 - OpenCode (`AGENTS.md`, `.opencode/plugins`, `.opencode/skills`, `.opencode/agents`)
-- both
 
 For non-interactive installs, pass the platform explicitly:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ cd your-project
 pip install hyperresearch && hyperresearch install
 ```
 
+Interactive setup asks which harness integrations to install:
+
+- Claude Code (`CLAUDE.md`, `.claude/settings*`, `.claude/skills`, `.claude/agents`)
+- OpenCode (`AGENTS.md`, `.opencode/plugins`, `.opencode/skills`, `.opencode/agents`)
+- both
+
+For non-interactive installs, pass the platform explicitly:
+
+```bash
+hyperresearch install --platform claude
+hyperresearch install --platform opencode
+hyperresearch install --platform both
+```
+
 Then `/hyperresearch <anything>` in Claude Code or OpenCode.
 
 Install writes `CLAUDE.md` and `AGENTS.md`, plus a Claude-compatible `PreToolUse` reminder hook in `.claude/settings.json` / `.claude/settings.local.json` and an OpenCode-native plugin in `.opencode/plugins/hyperresearch-reminder.js`. It also renders OpenCode-native subagents in `.opencode/agents/` with concrete models resolved from the active OpenCode config; if the same model is available through a flat-rate provider, that provider is preferred. OpenCode gets the same research-base nudge before web/search tools and blocks raw WebFetch for source pages.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd your-project
 pip install hyperresearch && hyperresearch install
 ```
 
-Interactive setup asks which harness integrations to install, with separate yes/no prompts for Claude Code and OpenCode:
+Interactive setup asks which harness integrations to install with a terminal checklist: use Tab/arrow keys to move, Space to toggle Claude Code or OpenCode, and Enter to confirm.
 
 - Claude Code (`CLAUDE.md`, `.claude/settings*`, `.claude/skills`, `.claude/agents`)
 - OpenCode (`AGENTS.md`, `.opencode/plugins`, `.opencode/skills`, `.opencode/agents`)

--- a/src/hyperresearch/cli/config_cmd.py
+++ b/src/hyperresearch/cli/config_cmd.py
@@ -125,7 +125,7 @@ def config_get(
 def config_agent_docs(
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON output"),
 ) -> None:
-    """Update CLAUDE.md with the latest hyperresearch blurb."""
+    """Update CLAUDE.md and AGENTS.md with the latest hyperresearch blurb."""
     from hyperresearch.core.agent_docs import inject_agent_docs
     from hyperresearch.core.vault import Vault
 
@@ -139,4 +139,4 @@ def config_agent_docs(
             for m in modified:
                 console.print(f"  [green]{m}[/]")
         else:
-            console.print("[dim]CLAUDE.md already up to date.[/]")
+            console.print("[dim]CLAUDE.md and AGENTS.md already up to date.[/]")

--- a/src/hyperresearch/cli/install.py
+++ b/src/hyperresearch/cli/install.py
@@ -18,7 +18,7 @@ def install(
         False,
         "--global",
         "-g",
-        help="Install Claude Code entry skill + agents to ~/.claude/ so /hyperresearch works in every Claude Code session anywhere. Skips vault init, CLAUDE.md, and the 16 step skills (those happen per-project on first /hyperresearch run).",
+        help="Install Claude Code entry skill + agents to ~/.claude/ so /hyperresearch works in every Claude Code session anywhere. Skips vault init, agent docs (CLAUDE.md/AGENTS.md), and the 16 step skills (those happen per-project on first /hyperresearch run).",
     ),
     steps_only: bool = typer.Option(
         False,
@@ -26,7 +26,7 @@ def install(
         help="Install only the 16 step skills to <PATH>/.claude/skills/. Used internally by the entry skill bootstrap on first /hyperresearch invocation in a project. Not normally invoked by users.",
     ),
 ) -> None:
-    """Install hyperresearch: init vault + inject CLAUDE.md + install Claude Code hooks."""
+    """Install hyperresearch: init vault + inject agent docs + install Claude Code hooks."""
     import sys
 
     from hyperresearch.core.hooks import (
@@ -57,7 +57,7 @@ def install(
         return
 
     # Global install path: only the user-level Claude Code entry skill +
-    # agents. No vault, no CLAUDE.md, no step skills — pure "make the
+    # agents. No vault, no agent docs, no step skills — pure "make the
     # slash command available everywhere" mode. Step skills install
     # per-project, lazily, when the entry skill bootstrap calls
     # `hyperresearch install --steps-only .` on first invocation.
@@ -124,7 +124,7 @@ def install(
 
     hpr_path = _resolve_executable()
 
-    # Step 3: Always re-inject CLAUDE.md (updates blurb + path)
+    # Step 3: Always re-inject agent docs (CLAUDE.md + AGENTS.md; updates blurb + path)
     doc_actions = inject_agent_docs(root)
 
     # Step 4: Install Claude Code hook + skills + subagents

--- a/src/hyperresearch/cli/install.py
+++ b/src/hyperresearch/cli/install.py
@@ -14,6 +14,12 @@ def install(
     path: str = typer.Argument(".", help="Path to install in"),
     name: str = typer.Option("Research Base", "--name", "-n", help="Vault name"),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON output"),
+    platform: str = typer.Option(
+        "ask",
+        "--platform",
+        "-p",
+        help="Harness integration(s) to install: claude, opencode, both. Default asks in interactive setup and uses both in non-interactive mode.",
+    ),
     global_install: bool = typer.Option(
         False,
         "--global",
@@ -101,8 +107,10 @@ def install(
     if is_new and is_interactive:
         from hyperresearch.cli.setup import setup
 
-        setup(path=path, json_output=False)
+        setup(path=path, json_output=False, platform=platform)
         return
+
+    selected_platforms = _resolve_platforms(platform, interactive=is_interactive)
 
     # Step 1: Init vault (skip if already exists)
     try:
@@ -110,7 +118,7 @@ def install(
         vault_action = "existing"
     except VaultError:
         try:
-            vault = Vault.init(root, name=name)
+            vault = Vault.init(root, name=name, platforms=selected_platforms)
             vault_action = "created"
         except VaultError as e:
             if json_output:
@@ -124,11 +132,11 @@ def install(
 
     hpr_path = _resolve_executable()
 
-    # Step 3: Always re-inject agent docs (CLAUDE.md + AGENTS.md; updates blurb + path)
-    doc_actions = inject_agent_docs(root)
+    # Step 3: Always re-inject selected agent docs (updates blurb + path)
+    doc_actions = inject_agent_docs(root, platforms=selected_platforms)
 
-    # Step 4: Install Claude Code hook + skills + subagents
-    hook_actions = install_hooks(root, hpr_path=hpr_path)
+    # Step 4: Install selected hooks + skills + subagents
+    hook_actions = install_hooks(root, hpr_path=hpr_path, platforms=selected_platforms)
 
     # Step 3: Auto-configure crawl4ai if installed
     crawl4ai_status = _setup_crawl4ai(vault)
@@ -137,6 +145,7 @@ def install(
     data = {
         "vault_path": str(vault.root),
         "vault": vault_action,
+        "platforms": sorted(selected_platforms),
         "agent_docs": doc_actions,
         "hooks_installed": hook_actions,
         "crawl4ai": crawl4ai_status,
@@ -174,6 +183,23 @@ def install(
 
         console.print("\n[bold]Ready.[/] Agents will now check the research base before web searches.")
         console.print("[dim]Tip: Run 'hyperresearch setup' for interactive configuration (profile, stealth, etc.)[/]")
+
+
+def _resolve_platforms(platform: str, interactive: bool) -> set[str]:
+    from hyperresearch.core.platforms import normalize_platforms
+
+    if platform == "ask":
+        if interactive:
+            from hyperresearch.cli.setup import choose_platforms_interactive
+
+            return choose_platforms_interactive()
+        return normalize_platforms("both")
+
+    try:
+        return normalize_platforms(platform)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/] {exc}")
+        raise typer.Exit(1) from exc
 
 
 def _setup_crawl4ai(vault) -> str:

--- a/src/hyperresearch/cli/setup.py
+++ b/src/hyperresearch/cli/setup.py
@@ -195,29 +195,86 @@ def setup(
 
 
 def choose_platforms_interactive() -> set[str]:
+    """Interactive checklist for selecting harness integrations."""
+    from hyperresearch.core.platforms import normalize_platforms
+
+    try:
+        return normalize_platforms(_run_platform_checklist())
+    except Exception:
+        # Curses can fail in constrained terminals (for example, dumb TERM or
+        # redirected stdio). Fall back to plain prompts rather than blocking install.
+        console.print()
+        console.print("[yellow]Interactive checklist unavailable; using plain prompts.[/]")
+        return normalize_platforms(_choose_platforms_prompt_fallback())
+
+
+def _run_platform_checklist() -> set[str]:
+    import curses
+
+    choices = [
+        ("claude", "Claude Code", "CLAUDE.md, .claude/settings, .claude/skills, .claude/agents"),
+        ("opencode", "OpenCode", "AGENTS.md, .opencode/plugins, .opencode/skills, .opencode/agents"),
+    ]
+    selected = {"claude", "opencode"}
+
+    def draw(stdscr, cursor: int, warning: str = "") -> None:
+        stdscr.clear()
+        try:
+            curses.curs_set(0)
+        except curses.error:
+            pass
+        stdscr.addstr(0, 0, "Agent Integrations")
+        stdscr.addstr(2, 0, "Tab/↑/↓ move • Space toggle • Enter confirm")
+        if warning:
+            stdscr.addstr(3, 0, warning)
+        for index, (value, label, description) in enumerate(choices):
+            marker = "[x]" if value in selected else "[ ]"
+            line = f"{marker} {label:<12} — {description}"
+            attrs = curses.A_REVERSE if index == cursor else curses.A_NORMAL
+            stdscr.addstr(5 + index, 0, line, attrs)
+        stdscr.refresh()
+
+    def run(stdscr) -> set[str]:
+        cursor = 0
+        warning = ""
+        while True:
+            draw(stdscr, cursor, warning)
+            key = stdscr.getch()
+            warning = ""
+            if key in (curses.KEY_UP, curses.KEY_BTAB):
+                cursor = (cursor - 1) % len(choices)
+            elif key in (curses.KEY_DOWN, ord("\t")):
+                cursor = (cursor + 1) % len(choices)
+            elif key == ord(" "):
+                value = choices[cursor][0]
+                if value in selected:
+                    selected.remove(value)
+                else:
+                    selected.add(value)
+            elif key in (curses.KEY_ENTER, 10, 13):
+                if selected:
+                    return set(selected)
+                warning = "Select at least one integration."
+            elif key in (27, ord("q")):
+                raise KeyboardInterrupt
+
+    return curses.wrapper(run)
+
+
+def _choose_platforms_prompt_fallback() -> set[str]:
     console.print()
     console.print(Rule("[bold]Agent Integrations", style="cyan"))
     console.print()
-    console.print("  Select the harness integrations to install:")
-    console.print("  [dim]Claude Code:[/] CLAUDE.md, .claude/settings, .claude/skills, .claude/agents")
-    console.print("  [dim]OpenCode:[/] AGENTS.md, .opencode/plugins, .opencode/skills, .opencode/agents")
-    console.print()
-
     while True:
         install_claude = Confirm.ask("  Install Claude Code integration?", default=True)
         install_opencode = Confirm.ask("  Install OpenCode integration?", default=True)
-
-        selected: list[str] = []
+        selected = set()
         if install_claude:
-            selected.append("claude")
+            selected.add("claude")
         if install_opencode:
-            selected.append("opencode")
-
+            selected.add("opencode")
         if selected:
-            from hyperresearch.core.platforms import normalize_platforms
-
-            return normalize_platforms(selected)
-
+            return selected
         console.print("  [yellow]Select at least one integration.[/]")
 
 

--- a/src/hyperresearch/cli/setup.py
+++ b/src/hyperresearch/cli/setup.py
@@ -198,28 +198,27 @@ def choose_platforms_interactive() -> set[str]:
     console.print()
     console.print(Rule("[bold]Agent Integrations", style="cyan"))
     console.print()
-    console.print("  Choose which harness integrations to install:")
-    console.print("  [bold]1[/] Claude Code  [dim]— CLAUDE.md, .claude/settings, .claude/skills, .claude/agents[/]")
-    console.print("  [bold]2[/] OpenCode     [dim]— AGENTS.md, .opencode/plugins, .opencode/skills, .opencode/agents[/]")
+    console.print("  Select the harness integrations to install:")
+    console.print("  [dim]Claude Code:[/] CLAUDE.md, .claude/settings, .claude/skills, .claude/agents")
+    console.print("  [dim]OpenCode:[/] AGENTS.md, .opencode/plugins, .opencode/skills, .opencode/agents")
     console.print()
-    raw = Prompt.ask("  Install integrations (comma-separated)", default="1,2")
 
-    mapping = {"1": "claude", "2": "opencode", "claude": "claude", "opencode": "opencode"}
-    selected: list[str] = []
-    for item in (part.strip().lower() for part in raw.split(",")):
-        if not item:
-            continue
-        mapped = mapping.get(item)
-        if mapped and mapped not in selected:
-            selected.append(mapped)
+    while True:
+        install_claude = Confirm.ask("  Install Claude Code integration?", default=True)
+        install_opencode = Confirm.ask("  Install OpenCode integration?", default=True)
 
-    if not selected:
-        console.print("  [yellow]No valid integration selected; defaulting to both.[/]")
-        selected = ["claude", "opencode"]
+        selected: list[str] = []
+        if install_claude:
+            selected.append("claude")
+        if install_opencode:
+            selected.append("opencode")
 
-    from hyperresearch.core.platforms import normalize_platforms
+        if selected:
+            from hyperresearch.core.platforms import normalize_platforms
 
-    return normalize_platforms(selected)
+            return normalize_platforms(selected)
+
+        console.print("  [yellow]Select at least one integration.[/]")
 
 
 def _normalize_platform_option(platform: str) -> set[str]:

--- a/src/hyperresearch/cli/setup.py
+++ b/src/hyperresearch/cli/setup.py
@@ -18,12 +18,20 @@ console = Console()
 def setup(
     path: str = typer.Argument(".", help="Path to set up"),
     json_output: bool = typer.Option(False, "--json", "-j", help="JSON output (non-interactive)"),
+    platform: str = typer.Option(
+        "ask",
+        "--platform",
+        "-p",
+        help="Harness integration(s) to install: claude, opencode, both. Default asks interactively.",
+    ),
 ) -> None:
     """Interactive setup — configure hyperresearch step by step."""
     if json_output or not sys.stdin.isatty():
         import subprocess
 
         cmd = [sys.executable, "-m", "hyperresearch", "install", path]
+        if platform != "ask":
+            cmd.extend(["--platform", platform])
         if json_output:
             cmd.append("--json")
         raise typer.Exit(subprocess.call(cmd))
@@ -43,6 +51,7 @@ def setup(
     )
 
     vault_name = "Research Base"
+    platforms = choose_platforms_interactive() if platform == "ask" else _normalize_platform_option(platform)
 
     # ── Step 1: Web Provider ──────────────────────────────────────
     console.print()
@@ -126,7 +135,7 @@ def setup(
         vault = Vault.discover(root)
         console.print(f"  [dim]Vault:[/] {vault.root}")
     except VaultError:
-        vault = Vault.init(root, name=vault_name)
+        vault = Vault.init(root, name=vault_name, platforms=platforms)
         console.print(f"  [green]Vault created:[/] {vault.root}")
 
     # Write config — magic always on when crawl4ai is used
@@ -139,12 +148,12 @@ def setup(
 
     # Inject agent docs (CLAUDE.md + AGENTS.md)
     hpr_path = _resolve_executable()
-    doc_actions = inject_agent_docs(root)
+    doc_actions = inject_agent_docs(root, platforms=platforms)
     for action in doc_actions:
         console.print(f"  [green]Docs:[/] {action}")
 
     # Install Claude Code hook + skills + subagents
-    hook_actions = install_hooks(root, hpr_path=hpr_path)
+    hook_actions = install_hooks(root, hpr_path=hpr_path, platforms=platforms)
     for action in hook_actions:
         console.print(f"  [green]Hook:[/] {action}")
     if not hook_actions:
@@ -164,7 +173,7 @@ def setup(
     summary.add_row("Provider", f"[bold]{provider}[/]")
     summary.add_row("Profile", f"[bold]{profile_desc}[/]")
     summary.add_row("Stealth", "[bold]on[/]" if magic else "[dim]off[/]")
-    summary.add_row("Platform", "[bold]Claude Code[/]")
+    summary.add_row("Platforms", f"[bold]{', '.join(sorted(platforms))}[/]")
     summary.add_row("CLI", f"[dim]{hpr_path}[/]")
 
     console.print(
@@ -183,6 +192,44 @@ def setup(
 
 
 # ── Helpers ─────────────────────────────────────────────────────
+
+
+def choose_platforms_interactive() -> set[str]:
+    console.print()
+    console.print(Rule("[bold]Agent Integrations", style="cyan"))
+    console.print()
+    console.print("  Choose which harness integrations to install:")
+    console.print("  [bold]1[/] Claude Code  [dim]— CLAUDE.md, .claude/settings, .claude/skills, .claude/agents[/]")
+    console.print("  [bold]2[/] OpenCode     [dim]— AGENTS.md, .opencode/plugins, .opencode/skills, .opencode/agents[/]")
+    console.print()
+    raw = Prompt.ask("  Install integrations (comma-separated)", default="1,2")
+
+    mapping = {"1": "claude", "2": "opencode", "claude": "claude", "opencode": "opencode"}
+    selected: list[str] = []
+    for item in (part.strip().lower() for part in raw.split(",")):
+        if not item:
+            continue
+        mapped = mapping.get(item)
+        if mapped and mapped not in selected:
+            selected.append(mapped)
+
+    if not selected:
+        console.print("  [yellow]No valid integration selected; defaulting to both.[/]")
+        selected = ["claude", "opencode"]
+
+    from hyperresearch.core.platforms import normalize_platforms
+
+    return normalize_platforms(selected)
+
+
+def _normalize_platform_option(platform: str) -> set[str]:
+    from hyperresearch.core.platforms import normalize_platforms
+
+    try:
+        return normalize_platforms(platform)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/] {exc}")
+        raise typer.Exit(1) from exc
 
 
 def _pick_existing_profile(profiles: list[str]) -> str:

--- a/src/hyperresearch/cli/setup.py
+++ b/src/hyperresearch/cli/setup.py
@@ -137,7 +137,7 @@ def setup(
     vault.config.name = vault_name
     vault.config.save(vault.config_path)
 
-    # Inject CLAUDE.md
+    # Inject agent docs (CLAUDE.md + AGENTS.md)
     hpr_path = _resolve_executable()
     doc_actions = inject_agent_docs(root)
     for action in doc_actions:

--- a/src/hyperresearch/core/agent_docs.py
+++ b/src/hyperresearch/core/agent_docs.py
@@ -1,10 +1,9 @@
-"""Agent documentation integration — inject the hyperresearch blurb into CLAUDE.md.
+"""Agent documentation integration — inject hyperresearch docs into agent rule files.
 
-hyperresearch is a Claude Code harness. This module writes/updates CLAUDE.md
-at the vault root so Claude Code auto-loads the research workflow on every
-session. Pre-existing AGENTS.md / GEMINI.md / .github/copilot-instructions.md
-files (from older hyperresearch vaults or other tools) are left alone — we
-don't delete user content, but we no longer generate them either.
+hyperresearch writes/updates project-level instructions for both Claude Code
+and OpenCode by maintaining matching sections in CLAUDE.md and AGENTS.md at
+the vault root. Pre-existing GEMINI.md / .github/copilot-instructions.md files
+(from older vaults or other tools) are left alone.
 """
 
 from __future__ import annotations
@@ -27,7 +26,7 @@ This project uses hyperresearch as an agent-driven research knowledge base. The 
 
 ### How to do research
 
-**Run a research session with `/hyperresearch <query>`.** This invokes the V8 16-step pipeline. The entry skill at `.claude/skills/hyperresearch/SKILL.md` is a thin ROUTER. The 16 step procedures live in their own skills (`hyperresearch-1-decompose` through `hyperresearch-16-readability-audit`) and are loaded fresh into context via the `Skill` tool when each step runs. This solves V7's context-compaction problem: each step's procedure lands in context only when needed. Read the entry skill before you start a research session; it explains the chain mechanics.
+**Run a research session with `/hyperresearch <query>`.** This invokes the V8 16-step pipeline. The entry skill at `.claude/skills/hyperresearch/SKILL.md` is a thin ROUTER (OpenCode can load this via its Claude-compat skill path). The 16 step procedures live in their own skills (`hyperresearch-1-decompose` through `hyperresearch-16-readability-audit`) and are loaded fresh into context via the `Skill` tool when each step runs. This solves V7's context-compaction problem: each step's procedure lands in context only when needed. Read the entry skill before you start a research session; it explains the chain mechanics.
 
 Step 1 classifies the query into one of two tiers (`light` or `full`) and the rest of the pipeline scales accordingly — short bounded queries skip the depth investigations, critics, and patcher (~30-40 min); argumentative deep-research queries run all 16 steps with adversarial review (~1.5-2.5 hours).
 
@@ -149,13 +148,10 @@ def _resolve_executable() -> str:
 
 
 def inject_agent_docs(vault_root: Path) -> list[str]:
-    """Inject hyperresearch docs into CLAUDE.md at the vault root.
+    """Inject hyperresearch docs into CLAUDE.md and AGENTS.md at vault root.
 
-    Always writes/updates CLAUDE.md. Does NOT touch AGENTS.md, GEMINI.md,
-    or .github/copilot-instructions.md — hyperresearch is a Claude Code
-    harness now, not a multi-platform tool. Pre-existing non-Claude doc
-    files are left untouched (we don't delete user content), but no new
-    ones are created.
+    Both files are maintained so the same project instructions are available
+    to Claude Code and OpenCode.
     """
     hpr_path = _resolve_executable()
     # Use forward slashes — bash on Windows eats backslashes
@@ -169,9 +165,10 @@ def inject_agent_docs(vault_root: Path) -> list[str]:
     )
 
     modified: list[str] = []
-    result = _inject_into_file(vault_root / "CLAUDE.md", blurb, "CLAUDE.md")
-    if result:
-        modified.append(result)
+    for filename in ("CLAUDE.md", "AGENTS.md"):
+        result = _inject_into_file(vault_root / filename, blurb, filename)
+        if result:
+            modified.append(result)
     return modified
 
 

--- a/src/hyperresearch/core/agent_docs.py
+++ b/src/hyperresearch/core/agent_docs.py
@@ -9,6 +9,7 @@ the vault root. Pre-existing GEMINI.md / .github/copilot-instructions.md files
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from pathlib import Path
 
 HYPERRESEARCH_SECTION_MARKER = "<!-- hyperresearch:start -->"
@@ -147,12 +148,14 @@ def _resolve_executable() -> str:
     return "hyperresearch"
 
 
-def inject_agent_docs(vault_root: Path) -> list[str]:
-    """Inject hyperresearch docs into CLAUDE.md and AGENTS.md at vault root.
+def inject_agent_docs(vault_root: Path, platforms: str | Iterable[str] | None = None) -> list[str]:
+    """Inject hyperresearch docs into selected agent rule files.
 
-    Both files are maintained so the same project instructions are available
-    to Claude Code and OpenCode.
+    Claude Code uses ``CLAUDE.md`` and OpenCode uses ``AGENTS.md``.
     """
+    from hyperresearch.core.platforms import normalize_platforms
+
+    selected = normalize_platforms(platforms)
     hpr_path = _resolve_executable()
     # Use forward slashes — bash on Windows eats backslashes
     hpr_path = hpr_path.replace("\\", "/")
@@ -165,7 +168,12 @@ def inject_agent_docs(vault_root: Path) -> list[str]:
     )
 
     modified: list[str] = []
-    for filename in ("CLAUDE.md", "AGENTS.md"):
+    targets = []
+    if "claude" in selected:
+        targets.append("CLAUDE.md")
+    if "opencode" in selected:
+        targets.append("AGENTS.md")
+    for filename in targets:
         result = _inject_into_file(vault_root / filename, blurb, filename)
         if result:
             modified.append(result)

--- a/src/hyperresearch/core/hooks.py
+++ b/src/hyperresearch/core/hooks.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterable
 from pathlib import Path
 
 # Scaffold-only section headers that must NEVER appear in a final_report draft.
@@ -3022,8 +3023,12 @@ export const HyperresearchOpenCodePlugin = async (ctx) => {{
 """
 
 
-def install_hooks(vault_root: Path, hpr_path: str = "hyperresearch") -> list[str]:
-    """Install the Claude/OpenCode-compatible hook + skills + subagents.
+def install_hooks(
+    vault_root: Path,
+    hpr_path: str = "hyperresearch",
+    platforms: str | Iterable[str] | None = None,
+) -> list[str]:
+    """Install selected harness integrations, hooks, skills, and subagents.
 
     Hyperresearch roster (as of v7):
       fetcher (Layer 1, 3, 4), loci-analyst (Layer 2), depth-investigator (Layer 3),
@@ -3032,11 +3037,13 @@ def install_hooks(vault_root: Path, hpr_path: str = "hyperresearch") -> list[str
       dialectic-critic + depth-critic + width-critic + instruction-critic (Layer 5),
       patcher (Layer 6), polish-auditor (Layer 7).
     """
+    from hyperresearch.core.platforms import normalize_platforms
+
+    selected = normalize_platforms(platforms)
     actions = []
 
-    for installer in (
+    claude_installers = (
         lambda: _install_claude_hook(vault_root, hpr_path),
-        lambda: _install_opencode_plugin(vault_root, hpr_path),
         lambda: _install_hyperresearch_skill(vault_root),
         lambda: _install_hyperresearch_step_skills(vault_root),
         lambda: _install_researcher_agent(vault_root, hpr_path),
@@ -3053,9 +3060,23 @@ def install_hooks(vault_root: Path, hpr_path: str = "hyperresearch") -> list[str
         lambda: _install_corpus_critic_agent(vault_root, hpr_path),
         lambda: _install_draft_orchestrator_agent(vault_root, hpr_path),
         lambda: _install_synthesizer_agent(vault_root, hpr_path),
-        lambda: _install_opencode_agents(vault_root),
         lambda: _prune_retired_agents(vault_root),
-    ):
+    )
+
+    opencode_installers = (
+        lambda: _install_opencode_plugin(vault_root, hpr_path),
+        lambda: _install_opencode_hyperresearch_skill(vault_root),
+        lambda: _install_opencode_step_skills(vault_root),
+        lambda: _install_opencode_agents(vault_root, hpr_path),
+    )
+
+    installers = []
+    if "claude" in selected:
+        installers.extend(claude_installers)
+    if "opencode" in selected:
+        installers.extend(opencode_installers)
+
+    for installer in installers:
         result = installer()
         if result:
             actions.append(result)
@@ -3226,31 +3247,51 @@ def _install_opencode_plugin(vault_root: Path, hpr_path: str) -> str | None:
     return "OpenCode: .opencode/plugins/hyperresearch-reminder.js (tool hooks)"
 
 
-def _install_opencode_agents(vault_root: Path) -> str | None:
+def _install_opencode_agents(vault_root: Path, hpr_path: str) -> str | None:
     """Render OpenCode-native subagents with concrete configured models."""
     from hyperresearch.core.opencode_models import resolve_opencode_model_choices
-
-    claude_agents_dir = vault_root / ".claude" / "agents"
-    if not claude_agents_dir.is_dir():
-        return None
 
     model_choices = resolve_opencode_model_choices(vault_root)
     opencode_agents_dir = vault_root / ".opencode" / "agents"
     opencode_agents_dir.mkdir(parents=True, exist_ok=True)
 
     changed: list[str] = []
-    for claude_agent_path in sorted(claude_agents_dir.glob("*.md")):
-        content = claude_agent_path.read_text(encoding="utf-8")
+    for filename, content in _agent_sources(hpr_path):
         opencode_content = _render_opencode_agent(content, model_choices)
-        opencode_agent_path = opencode_agents_dir / claude_agent_path.name
+        opencode_agent_path = opencode_agents_dir / filename
         if opencode_agent_path.exists() and opencode_agent_path.read_text(encoding="utf-8") == opencode_content:
             continue
         opencode_agent_path.write_text(opencode_content, encoding="utf-8")
-        changed.append(claude_agent_path.name)
+        changed.append(filename)
 
     if not changed:
         return None
     return f"OpenCode: .opencode/agents/ ({len(changed)} model-configured agents)"
+
+
+def _agent_sources(hpr_path: str) -> list[tuple[str, str]]:
+    hpr_posix = hpr_path.replace("\\", "/")
+    return [
+        ("hyperresearch-fetcher.md", RESEARCHER_AGENT.format(hpr_path=hpr_posix)),
+        ("hyperresearch-loci-analyst.md", LOCI_ANALYST_AGENT.format(hpr_path=hpr_posix)),
+        ("hyperresearch-depth-investigator.md", DEPTH_INVESTIGATOR_AGENT.format(hpr_path=hpr_posix)),
+        ("hyperresearch-source-analyst.md", SOURCE_ANALYST_AGENT.format(hpr_path=hpr_posix)),
+        ("hyperresearch-corpus-critic.md", CORPUS_CRITIC_AGENT.replace("{hpr_path}", hpr_posix)),
+        ("hyperresearch-dialectic-critic.md", DIALECTIC_CRITIC_AGENT.format(hpr_path=hpr_posix)),
+        ("hyperresearch-depth-critic.md", DEPTH_CRITIC_AGENT.format(hpr_path=hpr_posix)),
+        ("hyperresearch-width-critic.md", WIDTH_CRITIC_AGENT.format(hpr_path=hpr_posix)),
+        ("hyperresearch-instruction-critic.md", INSTRUCTION_CRITIC_AGENT),
+        ("hyperresearch-patcher.md", PATCHER_AGENT),
+        (
+            "hyperresearch-polish-auditor.md",
+            POLISH_AUDITOR_AGENT.format(
+                scaffold_only_sections=_render_scaffold_only_bullets(indent="- "),
+            ),
+        ),
+        ("hyperresearch-readability-recommender.md", READABILITY_REFORMATTER_AGENT),
+        ("hyperresearch-draft-orchestrator.md", DRAFT_ORCHESTRATOR_AGENT.replace("{hpr_path}", hpr_posix)),
+        ("hyperresearch-synthesizer.md", SYNTHESIZER_AGENT),
+    ]
 
 
 def _render_opencode_agent(content: str, model_choices) -> str:
@@ -3629,19 +3670,39 @@ _HYPERRESEARCH_STEP_SKILLS = [
 
 
 def _install_hyperresearch_step_skills(vault_root: Path) -> str | None:
-    """Install the 16 V8 step skills, each as its own Claude Code skill directory.
+    result = _install_step_skills(vault_root / ".claude" / "skills")
+    if result is None:
+        return None
+    return f"Claude Code: .claude/skills/hyperresearch-N-*/SKILL.md ({result})"
 
-    Each step skill lives at `.claude/skills/hyperresearch-N-name/SKILL.md` and is
-    invocable via the Skill tool. The orchestrator (loaded via /hyperresearch)
-    invokes each step skill in sequence per the tier routing table. This
-    decomposition solves the V7 context-compaction problem: each step's
-    procedure is loaded fresh into context only at the moment it's needed.
 
-    Also prunes any stale `hyperresearch-*` skill directories (e.g. from a prior
-    V8 layout where steps were numbered differently) so the user doesn't see
-    obsolete entries in their skill list.
+def _install_opencode_hyperresearch_skill(vault_root: Path) -> str | None:
+    content = _read_skill_source("hyperresearch.md")
+    if content is None:
+        return None
+
+    skill_dir = vault_root / ".opencode" / "skills" / "hyperresearch"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    dest_path = skill_dir / "SKILL.md"
+    if dest_path.exists() and dest_path.read_text(encoding="utf-8") == content:
+        return None
+    dest_path.write_text(content, encoding="utf-8")
+    return "OpenCode: .opencode/skills/hyperresearch/SKILL.md (/hyperresearch skill)"
+
+
+def _install_opencode_step_skills(vault_root: Path) -> str | None:
+    result = _install_step_skills(vault_root / ".opencode" / "skills")
+    if result is None:
+        return None
+    return f"OpenCode: .opencode/skills/hyperresearch-N-*/SKILL.md ({result})"
+
+
+def _install_step_skills(skills_root: Path) -> str | None:
+    """Install the 16 V8 step skills into a harness-specific skills root.
+
+    Each step skill lives at `<skills_root>/hyperresearch-N-name/SKILL.md` and is
+    invocable via the harness skill tool.
     """
-    skills_root = vault_root / ".claude" / "skills"
     skills_root.mkdir(parents=True, exist_ok=True)
 
     expected = set(_HYPERRESEARCH_STEP_SKILLS)
@@ -3686,4 +3747,4 @@ def _install_hyperresearch_step_skills(vault_root: Path) -> str | None:
         parts.append(f"{len(installed)} step skills: {', '.join(installed)}")
     if pruned:
         parts.append(f"pruned: {', '.join(pruned)}")
-    return f"Claude Code: .claude/skills/hyperresearch-N-*/SKILL.md ({'; '.join(parts)})"
+    return "; ".join(parts)

--- a/src/hyperresearch/core/hooks.py
+++ b/src/hyperresearch/core/hooks.py
@@ -1,10 +1,10 @@
-"""Agent hook installer — installs the Claude Code PreToolUse hook, skills, and subagents.
+"""Agent hook installer — installs Claude-compatible hooks, skills, and subagents.
 
-The hook reminds Claude Code to check the research base before doing raw web
-searches. The `/hyperresearch` skill drives the research
-protocol. The hyperresearch subagents (fetcher, loci-analyst, depth-investigator,
-four critics, patcher, polish-auditor) are Claude Code registered agents
-spawned via the Task tool.
+The hook reminds Claude Code and OpenCode-compatible runners to check the
+research base before doing raw web searches. The `/hyperresearch` skill drives
+the research protocol. The hyperresearch subagents (fetcher, loci-analyst,
+depth-investigator, four critics, patcher, polish-auditor) are registered as
+Claude-compatible agents spawned via the Task tool.
 """
 
 from __future__ import annotations
@@ -2904,6 +2904,7 @@ const fs = require('fs');
 const path = require('path');
 
 const HPR = '{hpr_path}';
+const REMINDER_TOOLS = new Set(['websearch', 'webfetch', 'grep', 'glob']);
 
 // Check if a .hyperresearch directory exists (vault is initialized)
 function findVault() {{
@@ -2916,8 +2917,13 @@ function findVault() {{
     }}
 }}
 
-const vault = findVault();
-if (vault) {{
+function shouldEmitReminder(payload) {{
+    const toolName = String(payload?.tool_name ?? payload?.tool ?? '').toLowerCase();
+    if (!toolName) return true; // Unknown runner payload → preserve old behavior.
+    return REMINDER_TOOLS.has(toolName);
+}}
+
+function emitReminder() {{
     const msg = [
         'HYPERRESEARCH: A research knowledge base exists in this project.',
         '',
@@ -2934,11 +2940,89 @@ if (vault) {{
     ].join('\\n');
     process.stderr.write(msg + '\\n');
 }}
+
+const vault = findVault();
+if (!vault) process.exit(0);
+
+let input = '';
+let finalized = false;
+
+function finalize() {{
+    if (finalized) return;
+    finalized = true;
+    let payload = null;
+    try {{
+        payload = input.trim() ? JSON.parse(input) : null;
+    }} catch (_) {{
+        payload = null;
+    }}
+    if (shouldEmitReminder(payload)) emitReminder();
+}}
+
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', finalize);
+process.stdin.on('error', finalize);
+setTimeout(finalize, 150);
+"""
+
+
+OPENCODE_PLUGIN_TEMPLATE = """\
+/**
+ * hyperresearch OpenCode plugin — nudges agents toward the persistent vault
+ * before external web work, and blocks raw WebFetch for source pages.
+ * Installed by: hyperresearch install
+ */
+const fs = require('fs');
+const path = require('path');
+
+const HPR = '{hpr_path}';
+
+function findVault(start) {{
+    let dir = start || process.cwd();
+    while (true) {{
+        if (fs.existsSync(path.join(dir, '.hyperresearch'))) return dir;
+        const parent = path.dirname(dir);
+        if (parent === dir) return null;
+        dir = parent;
+    }}
+}}
+
+function reminder() {{
+    return [
+        'HYPERRESEARCH: A research knowledge base exists in this project.',
+        'Before web search, check existing research with:',
+        '  ' + HPR + ' search "<your query>" -j',
+        'For source pages, do not use raw WebFetch. Use:',
+        '  ' + HPR + ' fetch "<url>" --tag <topic> -j',
+        'This saves full content, screenshots/assets where supported, and indexes sources for future sessions.',
+    ].join('\\n');
+}}
+
+export const HyperresearchOpenCodePlugin = async (ctx) => {{
+    const vault = findVault(ctx.directory || ctx.worktree || process.cwd());
+    if (!vault) return {{}};
+
+    return {{
+        'tool.definition': async (input, output) => {{
+            const tool = String(input?.toolID ?? '').toLowerCase();
+            if (tool === 'websearch' || tool === 'webfetch') {{
+                output.description = reminder() + '\\n\\n' + output.description;
+            }}
+        }},
+        'tool.execute.before': async (input) => {{
+            const tool = String(input?.tool ?? '').toLowerCase();
+            if (tool === 'webfetch') {{
+                throw new Error(reminder());
+            }}
+        }},
+    }};
+}};
 """
 
 
 def install_hooks(vault_root: Path, hpr_path: str = "hyperresearch") -> list[str]:
-    """Install the Claude Code hook + skills + subagents. Returns list of actions taken.
+    """Install the Claude/OpenCode-compatible hook + skills + subagents.
 
     Hyperresearch roster (as of v7):
       fetcher (Layer 1, 3, 4), loci-analyst (Layer 2), depth-investigator (Layer 3),
@@ -2951,6 +3035,7 @@ def install_hooks(vault_root: Path, hpr_path: str = "hyperresearch") -> list[str
 
     for installer in (
         lambda: _install_claude_hook(vault_root, hpr_path),
+        lambda: _install_opencode_plugin(vault_root, hpr_path),
         lambda: _install_hyperresearch_skill(vault_root),
         lambda: _install_hyperresearch_step_skills(vault_root),
         lambda: _install_researcher_agent(vault_root, hpr_path),
@@ -3073,13 +3158,29 @@ def _write_hook_script(vault_root: Path, hpr_path: str) -> Path:
 
 
 def _install_claude_hook(vault_root: Path, hpr_path: str) -> str | None:
-    """Install PreToolUse hook into .claude/settings.json."""
-    hook_path = _write_hook_script(vault_root, hpr_path)
+    """Install the Claude-compatible PreToolUse hook settings.
 
+    Claude Code reads `.claude/settings.json`. Some OpenCode hook bridges and
+    compatibility layers prefer project-local `.claude/settings.local.json`, so
+    write both with the same command hook. The hook script itself accepts both
+    Claude's `tool_name` payload and OpenCode-style lowercase `tool` payloads.
+    """
+    hook_path = _write_hook_script(vault_root, hpr_path)
     settings_dir = vault_root / ".claude"
     settings_dir.mkdir(exist_ok=True)
-    settings_path = settings_dir / "settings.json"
 
+    changed_paths: list[str] = []
+    for settings_name in ("settings.json", "settings.local.json"):
+        settings_path = settings_dir / settings_name
+        if _ensure_pretool_hook(settings_path, hook_path):
+            changed_paths.append(f".claude/{settings_name}")
+
+    if not changed_paths:
+        return None
+    return f"Claude/OpenCode: {', '.join(changed_paths)} (PreToolUse hook)"
+
+
+def _ensure_pretool_hook(settings_path: Path, hook_path: Path) -> bool:
     settings = {}
     if settings_path.exists():
         try:
@@ -3092,12 +3193,12 @@ def _install_claude_hook(vault_root: Path, hpr_path: str) -> str | None:
 
     for entry in pre_tool:
         if isinstance(entry, dict):
-            for h in entry.get("hooks", []):
-                if "hyperresearch" in h.get("command", ""):
-                    return None
+            for hook in entry.get("hooks", []):
+                if isinstance(hook, dict) and "hyperresearch" in hook.get("command", ""):
+                    return False
 
     pre_tool.append({
-        "matcher": "Glob|Grep|WebSearch|WebFetch",
+        "matcher": "Glob|Grep|WebSearch|WebFetch|glob|grep|websearch|webfetch",
         "hooks": [{
             "type": "command",
             "command": f"node {hook_path.as_posix()}",
@@ -3105,7 +3206,22 @@ def _install_claude_hook(vault_root: Path, hpr_path: str) -> str | None:
     })
 
     settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
-    return "Claude Code: .claude/settings.json (PreToolUse hook)"
+    return True
+
+
+def _install_opencode_plugin(vault_root: Path, hpr_path: str) -> str | None:
+    """Install an OpenCode-native plugin hook into .opencode/plugins/."""
+    plugins_dir = vault_root / ".opencode" / "plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    plugin_path = plugins_dir / "hyperresearch-reminder.js"
+    js_path = hpr_path.replace("\\", "\\\\")
+    content = OPENCODE_PLUGIN_TEMPLATE.format(hpr_path=js_path)
+
+    if plugin_path.exists() and plugin_path.read_text(encoding="utf-8") == content:
+        return None
+
+    plugin_path.write_text(content, encoding="utf-8")
+    return "OpenCode: .opencode/plugins/hyperresearch-reminder.js (tool hooks)"
 
 
 def _write_agent_file(

--- a/src/hyperresearch/core/hooks.py
+++ b/src/hyperresearch/core/hooks.py
@@ -3294,6 +3294,29 @@ def _agent_sources(hpr_path: str) -> list[tuple[str, str]]:
     ]
 
 
+_OPENCODE_ALLOWED_COLORS: set[str] = {
+    "primary",
+    "secondary",
+    "accent",
+    "success",
+    "warning",
+    "error",
+    "info",
+}
+
+_OPENCODE_COLOR_ALIASES: dict[str, str] = {
+    "red": "error",
+    "orange": "warning",
+    "yellow": "warning",
+    "green": "success",
+    "teal": "info",
+    "cyan": "info",
+    "blue": "primary",
+    "purple": "secondary",
+    "magenta": "accent",
+}
+
+
 def _render_opencode_agent(content: str, model_choices) -> str:
     frontmatter_match = re.match(r"^---\n(?P<frontmatter>.*?)\n---\n(?P<body>.*)$", content, re.DOTALL)
     if not frontmatter_match:
@@ -3321,6 +3344,16 @@ def _render_opencode_agent(content: str, model_choices) -> str:
             continue
         if stripped.startswith("tools:"):
             tool_names = [part.strip() for part in stripped.split(":", 1)[1].split(",")]
+            continue
+        if stripped.startswith("color:"):
+            raw_color = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+            lowered = raw_color.lower()
+            if lowered in _OPENCODE_ALLOWED_COLORS:
+                rendered.append(f"color: {lowered}")
+            elif re.fullmatch(r"#[0-9a-fA-F]{6}", raw_color):
+                rendered.append(f"color: {raw_color}")
+            else:
+                rendered.append(f"color: {_OPENCODE_COLOR_ALIASES.get(lowered, 'primary')}")
             continue
         if stripped.startswith("mode:"):
             has_mode = True

--- a/src/hyperresearch/core/hooks.py
+++ b/src/hyperresearch/core/hooks.py
@@ -10,6 +10,7 @@ Claude-compatible agents spawned via the Task tool.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 # Scaffold-only section headers that must NEVER appear in a final_report draft.
@@ -3052,6 +3053,7 @@ def install_hooks(vault_root: Path, hpr_path: str = "hyperresearch") -> list[str
         lambda: _install_corpus_critic_agent(vault_root, hpr_path),
         lambda: _install_draft_orchestrator_agent(vault_root, hpr_path),
         lambda: _install_synthesizer_agent(vault_root, hpr_path),
+        lambda: _install_opencode_agents(vault_root),
         lambda: _prune_retired_agents(vault_root),
     ):
         result = installer()
@@ -3222,6 +3224,96 @@ def _install_opencode_plugin(vault_root: Path, hpr_path: str) -> str | None:
 
     plugin_path.write_text(content, encoding="utf-8")
     return "OpenCode: .opencode/plugins/hyperresearch-reminder.js (tool hooks)"
+
+
+def _install_opencode_agents(vault_root: Path) -> str | None:
+    """Render OpenCode-native subagents with concrete configured models."""
+    from hyperresearch.core.opencode_models import resolve_opencode_model_choices
+
+    claude_agents_dir = vault_root / ".claude" / "agents"
+    if not claude_agents_dir.is_dir():
+        return None
+
+    model_choices = resolve_opencode_model_choices(vault_root)
+    opencode_agents_dir = vault_root / ".opencode" / "agents"
+    opencode_agents_dir.mkdir(parents=True, exist_ok=True)
+
+    changed: list[str] = []
+    for claude_agent_path in sorted(claude_agents_dir.glob("*.md")):
+        content = claude_agent_path.read_text(encoding="utf-8")
+        opencode_content = _render_opencode_agent(content, model_choices)
+        opencode_agent_path = opencode_agents_dir / claude_agent_path.name
+        if opencode_agent_path.exists() and opencode_agent_path.read_text(encoding="utf-8") == opencode_content:
+            continue
+        opencode_agent_path.write_text(opencode_content, encoding="utf-8")
+        changed.append(claude_agent_path.name)
+
+    if not changed:
+        return None
+    return f"OpenCode: .opencode/agents/ ({len(changed)} model-configured agents)"
+
+
+def _render_opencode_agent(content: str, model_choices) -> str:
+    frontmatter_match = re.match(r"^---\n(?P<frontmatter>.*?)\n---\n(?P<body>.*)$", content, re.DOTALL)
+    if not frontmatter_match:
+        return content
+
+    frontmatter = frontmatter_match.group("frontmatter")
+    body = frontmatter_match.group("body")
+    lines = frontmatter.splitlines()
+
+    rendered: list[str] = []
+    role = "sonnet"
+    tool_names: list[str] = []
+    has_mode = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("name:"):
+            continue
+        if stripped.startswith("model:"):
+            role = stripped.split(":", 1)[1].strip()
+            choice = model_choices.get(role) or model_choices["sonnet"]
+            rendered.append(f"model: {choice.model}")
+            if choice.variant:
+                rendered.append(f"variant: {choice.variant}")
+            continue
+        if stripped.startswith("tools:"):
+            tool_names = [part.strip() for part in stripped.split(":", 1)[1].split(",")]
+            continue
+        if stripped.startswith("mode:"):
+            has_mode = True
+        rendered.append(line)
+
+    if not has_mode:
+        rendered.append("mode: subagent")
+
+    permission = _opencode_permission_block(tool_names)
+    if permission:
+        rendered.extend(permission)
+
+    return "---\n" + "\n".join(rendered).rstrip() + "\n---\n" + body
+
+
+def _opencode_permission_block(tool_names: list[str]) -> list[str]:
+    allowed: list[str] = []
+    tools = {tool.lower() for tool in tool_names}
+    if "read" in tools:
+        allowed.append("read")
+    if "write" in tools or "edit" in tools:
+        allowed.append("edit")
+    if "bash" in tools:
+        allowed.append("bash")
+    if "task" in tools:
+        allowed.append("task")
+
+    if not allowed:
+        return []
+
+    lines = ["permission:"]
+    for name in allowed:
+        lines.append(f"  {name}: allow")
+    return lines
 
 
 def _write_agent_file(

--- a/src/hyperresearch/core/opencode_models.py
+++ b/src/hyperresearch/core/opencode_models.py
@@ -1,0 +1,258 @@
+"""OpenCode model resolution for hyperresearch agent generation.
+
+Claude Code supports convenient model aliases like ``opus`` and ``sonnet`` in
+agent frontmatter. OpenCode expects concrete ``provider/model`` IDs. This module
+maps hyperresearch's Claude roles onto the user's active OpenCode models while
+preserving quality intent:
+
+- ``opus`` -> strongest reasoning model available
+- ``sonnet`` -> balanced, high-throughput model available
+- ``haiku`` -> fast/cheap model available
+
+If the same underlying model is available through a flat-rate provider and a
+metered provider, the flat-rate provider wins.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+FLAT_RATE_PROVIDERS = {
+    "opencode-go",
+    "openai-codex",
+    "google-antigravity",
+    "copilot",
+    "github-copilot",
+}
+
+CONFIG_FILENAMES = (
+    "opencode.json",
+    "oh-my-openagent.json",
+    "oh-my-opencode.json",
+    "oh-my-opencode-slim.json",
+)
+
+FALLBACK_MODELS = {
+    "opus": "anthropic/claude-opus-4-1",
+    "sonnet": "anthropic/claude-sonnet-4-5",
+    "haiku": "anthropic/claude-haiku-4-5",
+}
+
+
+@dataclass(frozen=True)
+class OpenCodeModelChoice:
+    model: str
+    variant: str | None = None
+    source: str = "fallback"
+
+    @property
+    def provider(self) -> str:
+        return self.model.split("/", 1)[0] if "/" in self.model else ""
+
+    @property
+    def flat_rate(self) -> bool:
+        return self.provider in FLAT_RATE_PROVIDERS
+
+
+def resolve_opencode_model_choices(vault_root: Path | None = None) -> dict[str, OpenCodeModelChoice]:
+    """Resolve concrete OpenCode models for hyperresearch's model roles.
+
+    The resolver reads project and user OpenCode config files, extracts every
+    declared model, deduplicates equivalent provider/model pairs, then chooses
+    defaults for the ``opus``, ``sonnet``, and ``haiku`` roles.
+    """
+    active_models = _active_models(vault_root)
+    if not active_models:
+        return {
+            role: OpenCodeModelChoice(model=model, source="fallback")
+            for role, model in FALLBACK_MODELS.items()
+        }
+
+    active_models = _dedupe_equivalent_models(active_models)
+    return {
+        role: _choose_for_role(role, active_models)
+        for role in ("opus", "sonnet", "haiku")
+    }
+
+
+def _active_models(vault_root: Path | None) -> list[OpenCodeModelChoice]:
+    config_files = _config_files(vault_root)
+    choices: list[OpenCodeModelChoice] = []
+    for path in config_files:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        choices.extend(_extract_models(data, source=str(path)))
+    return choices
+
+
+def _config_files(vault_root: Path | None) -> list[Path]:
+    files: list[Path] = []
+
+    if vault_root is not None:
+        root = vault_root.resolve()
+        for name in CONFIG_FILENAMES:
+            files.append(root / name)
+            files.append(root / ".opencode" / name)
+
+    env_dir = os.environ.get("HYPERRESEARCH_OPENCODE_CONFIG_DIR")
+    config_root = (
+        Path(env_dir).expanduser()
+        if env_dir
+        else Path.home() / ".config" / "opencode"
+    )
+
+    for name in CONFIG_FILENAMES:
+        files.append(config_root / name)
+
+    seen: set[Path] = set()
+    existing: list[Path] = []
+    for path in files:
+        path = path.expanduser()
+        if path in seen:
+            continue
+        seen.add(path)
+        if path.exists():
+            existing.append(path)
+    return existing
+
+
+def _extract_models(node: Any, source: str, inherited_variant: str | None = None) -> list[OpenCodeModelChoice]:
+    choices: list[OpenCodeModelChoice] = []
+
+    if isinstance(node, dict):
+        variant = node.get("variant") if isinstance(node.get("variant"), str) else inherited_variant
+        for key, value in node.items():
+            if key in {"model", "small_model"} and isinstance(value, str):
+                choices.append(OpenCodeModelChoice(value, variant=variant, source=source))
+            else:
+                choices.extend(_extract_models(value, source=source, inherited_variant=variant))
+    elif isinstance(node, list):
+        for item in node:
+            choices.extend(_extract_models(item, source=source, inherited_variant=inherited_variant))
+
+    return choices
+
+
+def _dedupe_equivalent_models(models: list[OpenCodeModelChoice]) -> list[OpenCodeModelChoice]:
+    by_key: dict[str, OpenCodeModelChoice] = {}
+    for choice in models:
+        key = _model_key(choice.model)
+        existing = by_key.get(key)
+        if existing is None or _prefer_same_model(choice, existing):
+            by_key[key] = choice
+    return list(by_key.values())
+
+
+def _prefer_same_model(candidate: OpenCodeModelChoice, existing: OpenCodeModelChoice) -> bool:
+    if candidate.flat_rate != existing.flat_rate:
+        return candidate.flat_rate
+    return _variant_score(candidate.variant) > _variant_score(existing.variant)
+
+
+def _choose_for_role(role: str, models: list[OpenCodeModelChoice]) -> OpenCodeModelChoice:
+    scored = sorted(
+        models,
+        key=lambda choice: (
+            _role_score(role, choice),
+            1 if choice.flat_rate else 0,
+            _variant_score(choice.variant),
+            choice.model,
+        ),
+        reverse=True,
+    )
+    best = scored[0]
+    if _role_score(role, best) <= 0:
+        return OpenCodeModelChoice(FALLBACK_MODELS[role], source="fallback")
+    return best
+
+
+def _model_key(model: str) -> str:
+    if "/" in model:
+        return model.split("/", 1)[1].lower()
+    return model.lower()
+
+
+def _role_score(role: str, choice: OpenCodeModelChoice) -> int:
+    model = _model_key(choice.model)
+    score = _base_role_score(role, model)
+    score += _variant_score(choice.variant)
+    # Prefer flat-rate only as a tie-breaker or near-tie. A weaker flat-rate
+    # model should not replace a materially stronger reasoning model.
+    if choice.flat_rate:
+        score += 3
+    return score
+
+
+def _base_role_score(role: str, model: str) -> int:
+    if role == "opus":
+        return _score_opus(model)
+    if role == "sonnet":
+        return _score_sonnet(model)
+    if role == "haiku":
+        return _score_haiku(model)
+    return 0
+
+
+def _score_opus(model: str) -> int:
+    patterns = [
+        (r"opus", 110),
+        (r"gpt-5\.5", 100),
+        (r"gpt-5\.4", 92),
+        (r"glm-5", 88),
+        (r"kimi-k2\.6", 86),
+        (r"sonnet", 84),
+        (r"minimax-m2\.7", 70),
+    ]
+    return _pattern_score(model, patterns)
+
+
+def _score_sonnet(model: str) -> int:
+    patterns = [
+        (r"sonnet", 110),
+        (r"kimi-k2\.6", 96),
+        (r"glm-5", 94),
+        (r"gpt-5\.4", 92),
+        (r"minimax-m2\.7", 86),
+        (r"gpt-5\.5", 82),
+        (r"haiku", 58),
+    ]
+    return _pattern_score(model, patterns)
+
+
+def _score_haiku(model: str) -> int:
+    patterns = [
+        (r"haiku", 110),
+        (r"mini", 96),
+        (r"nano", 92),
+        (r"highspeed", 88),
+        (r"minimax-m2\.7", 84),
+        (r"kimi-k2\.6", 74),
+        (r"sonnet", 60),
+        (r"gpt-5\.5", 45),
+    ]
+    return _pattern_score(model, patterns)
+
+
+def _pattern_score(model: str, patterns: list[tuple[str, int]]) -> int:
+    for pattern, score in patterns:
+        if re.search(pattern, model):
+            return score
+    return 0
+
+
+def _variant_score(variant: str | None) -> int:
+    if variant is None:
+        return 0
+    return {
+        "xhigh": 8,
+        "high": 5,
+        "medium": 2,
+        "low": -1,
+    }.get(variant.lower(), 0)

--- a/src/hyperresearch/core/platforms.py
+++ b/src/hyperresearch/core/platforms.py
@@ -1,0 +1,50 @@
+"""Supported agent-harness platform selection."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+SUPPORTED_PLATFORMS = frozenset({"claude", "opencode"})
+PLATFORM_ALIASES = {
+    "claude-code": "claude",
+    "claude_code": "claude",
+    "claudecode": "claude",
+    "cc": "claude",
+    "open-code": "opencode",
+    "open_code": "opencode",
+    "oc": "opencode",
+}
+
+
+def normalize_platforms(platforms: str | Iterable[str] | None = None) -> set[str]:
+    """Normalize a platform selector into ``{"claude", "opencode"}`` subset.
+
+    Accepts ``both``/``all`` or comma-separated strings for CLI ergonomics.
+    """
+    if platforms is None:
+        return set(SUPPORTED_PLATFORMS)
+
+    if isinstance(platforms, str):
+        raw_items = [part.strip() for part in platforms.split(",")]
+    else:
+        raw_items = []
+        for item in platforms:
+            raw_items.extend(part.strip() for part in item.split(","))
+
+    selected: set[str] = set()
+    for item in raw_items:
+        if not item:
+            continue
+        normalized = item.lower()
+        if normalized in {"both", "all"}:
+            selected.update(SUPPORTED_PLATFORMS)
+            continue
+        normalized = PLATFORM_ALIASES.get(normalized, normalized)
+        if normalized not in SUPPORTED_PLATFORMS:
+            valid = ", ".join(sorted(SUPPORTED_PLATFORMS | {"both"}))
+            raise ValueError(f"Unknown platform '{item}'. Valid values: {valid}")
+        selected.add(normalized)
+
+    if not selected:
+        raise ValueError("At least one platform must be selected: claude, opencode, or both")
+    return selected

--- a/src/hyperresearch/core/vault.py
+++ b/src/hyperresearch/core/vault.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterable
 from pathlib import Path
 
 from hyperresearch.core.config import VaultConfig
@@ -95,7 +96,12 @@ class Vault:
         self.close()
 
     @staticmethod
-    def init(root: Path, name: str = "Research Base", research_dir: str = "research") -> Vault:
+    def init(
+        root: Path,
+        name: str = "Research Base",
+        research_dir: str = "research",
+        platforms: str | Iterable[str] | None = None,
+    ) -> Vault:
         """Initialize a new vault at the given path."""
         root = root.resolve()
         hyperresearch_dir = root / HYPERRESEARCH_DIR
@@ -138,7 +144,7 @@ class Vault:
 
         # Inject agent docs (CLAUDE.md + AGENTS.md) at vault root
         from hyperresearch.core.agent_docs import inject_agent_docs
-        inject_agent_docs(root)
+        inject_agent_docs(root, platforms=platforms)
 
         return vault
 

--- a/src/hyperresearch/core/vault.py
+++ b/src/hyperresearch/core/vault.py
@@ -136,7 +136,7 @@ class Vault:
             "# {{ title }}\n\n"
         )
 
-        # Inject CLAUDE.md at vault root
+        # Inject agent docs (CLAUDE.md + AGENTS.md) at vault root
         from hyperresearch.core.agent_docs import inject_agent_docs
         inject_agent_docs(root)
 

--- a/tests/test_cli/test_setup.py
+++ b/tests/test_cli/test_setup.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from hyperresearch.cli import setup as setup_cli
+
+
+def test_choose_platforms_interactive_uses_yes_no_selection(monkeypatch):
+    answers = iter([True, False])
+
+    monkeypatch.setattr(setup_cli.Confirm, "ask", lambda *args, **kwargs: next(answers))
+
+    assert setup_cli.choose_platforms_interactive() == {"claude"}
+
+
+def test_choose_platforms_interactive_requires_at_least_one(monkeypatch):
+    answers = iter([False, False, False, True])
+
+    monkeypatch.setattr(setup_cli.Confirm, "ask", lambda *args, **kwargs: next(answers))
+
+    assert setup_cli.choose_platforms_interactive() == {"opencode"}

--- a/tests/test_cli/test_setup.py
+++ b/tests/test_cli/test_setup.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 from hyperresearch.cli import setup as setup_cli
 
 
-def test_choose_platforms_interactive_uses_yes_no_selection(monkeypatch):
-    answers = iter([True, False])
-
-    monkeypatch.setattr(setup_cli.Confirm, "ask", lambda *args, **kwargs: next(answers))
+def test_choose_platforms_interactive_uses_checklist(monkeypatch):
+    monkeypatch.setattr(setup_cli, "_run_platform_checklist", lambda: {"claude"})
 
     assert setup_cli.choose_platforms_interactive() == {"claude"}
 
 
-def test_choose_platforms_interactive_requires_at_least_one(monkeypatch):
+def test_choose_platforms_interactive_falls_back_when_checklist_unavailable(monkeypatch):
     answers = iter([False, False, False, True])
 
+    def fail_checklist():
+        raise RuntimeError("no curses")
+
+    monkeypatch.setattr(setup_cli, "_run_platform_checklist", fail_checklist)
     monkeypatch.setattr(setup_cli.Confirm, "ask", lambda *args, **kwargs: next(answers))
 
     assert setup_cli.choose_platforms_interactive() == {"opencode"}

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
+import textwrap
+
 from hyperresearch.core.hooks import (
     _RETIRED_AGENT_FILES,
     _RETIRED_SKILL_DIRS,
@@ -381,9 +385,73 @@ def test_install_hooks_registers_full_hyperresearch_roster(tmp_vault):
     assert (tmp_vault.root / ".claude" / "skills" / "hyperresearch" / "SKILL.md").exists()
     assert not (tmp_vault.root / ".claude" / "skills" / "research" / "SKILL.md").exists()
 
-    # Hook settings written
-    assert (tmp_vault.root / ".claude" / "settings.json").exists()
+    # Hook settings written for Claude Code and OpenCode-compatible hook bridges.
+    settings_path = tmp_vault.root / ".claude" / "settings.json"
+    local_settings_path = tmp_vault.root / ".claude" / "settings.local.json"
+    opencode_plugin_path = tmp_vault.root / ".opencode" / "plugins" / "hyperresearch-reminder.js"
+    assert settings_path.exists()
+    assert local_settings_path.exists()
+    assert opencode_plugin_path.exists()
     assert (tmp_vault.root / ".hyperresearch" / "hook.js").exists()
+
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    matcher = settings["hooks"]["PreToolUse"][0]["matcher"]
+    assert "WebSearch" in matcher
+    assert "websearch" in matcher
+
+    opencode_plugin = opencode_plugin_path.read_text(encoding="utf-8")
+    assert "tool.definition" in opencode_plugin
+    assert "tool.execute.before" in opencode_plugin
+
+
+def test_opencode_plugin_executes_tool_hooks(tmp_vault, tmp_path):
+    install_hooks(tmp_vault.root, "hyperresearch")
+    plugin_path = tmp_vault.root / ".opencode" / "plugins" / "hyperresearch-reminder.js"
+
+    runner = tmp_path / "run-opencode-plugin.mjs"
+    runner.write_text(
+        textwrap.dedent(
+            f"""
+            import {{ HyperresearchOpenCodePlugin }} from {plugin_path.as_uri()!r};
+
+            const hooks = await HyperresearchOpenCodePlugin({{
+              directory: {str(tmp_vault.root)!r},
+              worktree: {str(tmp_vault.root)!r},
+            }});
+
+            const definitionOutput = {{ description: 'original description' }};
+            await hooks['tool.definition']({{ toolID: 'webfetch' }}, definitionOutput);
+            if (!definitionOutput.description.includes('HYPERRESEARCH')) {{
+              throw new Error('tool.definition did not inject hyperresearch reminder');
+            }}
+
+            let blocked = false;
+            try {{
+              await hooks['tool.execute.before']({{ tool: 'webfetch' }}, {{ args: {{ url: 'https://example.com' }} }});
+            }} catch (error) {{
+              blocked = String(error.message).includes('hyperresearch fetch');
+            }}
+            if (!blocked) {{
+              throw new Error('tool.execute.before did not block raw webfetch');
+            }}
+
+            await hooks['tool.execute.before']({{ tool: 'read' }}, {{ args: {{ filePath: 'README.md' }} }});
+            console.log('opencode plugin hooks verified');
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["bun", runner.as_posix()],
+        cwd=tmp_vault.root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "opencode plugin hooks verified" in result.stdout
 
 
 def test_install_hooks_second_run_is_noop(tmp_vault):

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -352,6 +352,40 @@ def test_prune_retired_agents_noop_on_clean_vault(tmp_vault):
 # ---------------------------------------------------------------------------
 
 
+def test_install_hooks_can_target_opencode_only(tmp_path, monkeypatch):
+    from hyperresearch.core.vault import Vault
+
+    empty_opencode_config = tmp_path / "empty-opencode"
+    empty_opencode_config.mkdir()
+    monkeypatch.setenv("HYPERRESEARCH_OPENCODE_CONFIG_DIR", str(empty_opencode_config))
+
+    vault = Vault.init(tmp_path / "opencode-only", platforms="opencode")
+    actions = install_hooks(vault.root, "hyperresearch", platforms="opencode")
+
+    assert actions
+    assert (vault.root / "AGENTS.md").exists()
+    assert not (vault.root / "CLAUDE.md").exists()
+    assert not (vault.root / ".claude").exists()
+    assert (vault.root / ".opencode" / "plugins" / "hyperresearch-reminder.js").exists()
+    assert (vault.root / ".opencode" / "skills" / "hyperresearch" / "SKILL.md").exists()
+    assert (vault.root / ".opencode" / "agents" / "hyperresearch-fetcher.md").exists()
+
+
+def test_install_hooks_can_target_claude_only(tmp_path):
+    from hyperresearch.core.vault import Vault
+
+    vault = Vault.init(tmp_path / "claude-only", platforms="claude")
+    actions = install_hooks(vault.root, "hyperresearch", platforms="claude")
+
+    assert actions
+    assert (vault.root / "CLAUDE.md").exists()
+    assert not (vault.root / "AGENTS.md").exists()
+    assert (vault.root / ".claude" / "settings.json").exists()
+    assert (vault.root / ".claude" / "skills" / "hyperresearch" / "SKILL.md").exists()
+    assert (vault.root / ".claude" / "agents" / "hyperresearch-fetcher.md").exists()
+    assert not (vault.root / ".opencode").exists()
+
+
 def test_install_hooks_registers_full_hyperresearch_roster(tmp_vault, tmp_path, monkeypatch):
     """install_hooks wires the hook, both entry-skill aliases, and the agent roster."""
     empty_opencode_config = tmp_path / "empty-opencode"

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -352,8 +352,12 @@ def test_prune_retired_agents_noop_on_clean_vault(tmp_vault):
 # ---------------------------------------------------------------------------
 
 
-def test_install_hooks_registers_full_hyperresearch_roster(tmp_vault):
+def test_install_hooks_registers_full_hyperresearch_roster(tmp_vault, tmp_path, monkeypatch):
     """install_hooks wires the hook, both entry-skill aliases, and the agent roster."""
+    empty_opencode_config = tmp_path / "empty-opencode"
+    empty_opencode_config.mkdir()
+    monkeypatch.setenv("HYPERRESEARCH_OPENCODE_CONFIG_DIR", str(empty_opencode_config))
+
     actions = install_hooks(tmp_vault.root, "hyperresearch")
     assert actions  # something happened
 
@@ -379,6 +383,20 @@ def test_install_hooks_registers_full_hyperresearch_roster(tmp_vault):
     assert expected_agents == actual_agents, (
         f"missing: {expected_agents - actual_agents}, extra: {actual_agents - expected_agents}"
     )
+
+    opencode_agents_dir = tmp_vault.root / ".opencode" / "agents"
+    actual_opencode_agents = {p.name for p in opencode_agents_dir.iterdir() if p.is_file()}
+    assert expected_agents == actual_opencode_agents
+
+    opencode_fetcher = (opencode_agents_dir / "hyperresearch-fetcher.md").read_text(
+        encoding="utf-8"
+    )
+    assert "model: anthropic/claude-sonnet" in opencode_fetcher
+    assert "model: sonnet" not in opencode_fetcher
+    assert "mode: subagent" in opencode_fetcher
+    assert "permission:" in opencode_fetcher
+    assert "  bash: allow" in opencode_fetcher
+    assert "tools: Bash" not in opencode_fetcher
 
     # Entry skill registered as /hyperresearch (the /research alias was
     # retired in v0.8.1)

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import textwrap
 
@@ -369,6 +370,30 @@ def test_install_hooks_can_target_opencode_only(tmp_path, monkeypatch):
     assert (vault.root / ".opencode" / "plugins" / "hyperresearch-reminder.js").exists()
     assert (vault.root / ".opencode" / "skills" / "hyperresearch" / "SKILL.md").exists()
     assert (vault.root / ".opencode" / "agents" / "hyperresearch-fetcher.md").exists()
+
+
+def test_opencode_agent_colors_are_schema_compatible(tmp_path, monkeypatch):
+    from hyperresearch.core.vault import Vault
+
+    empty_opencode_config = tmp_path / "empty-opencode"
+    empty_opencode_config.mkdir()
+    monkeypatch.setenv("HYPERRESEARCH_OPENCODE_CONFIG_DIR", str(empty_opencode_config))
+
+    vault = Vault.init(tmp_path / "opencode-color-check", platforms="opencode")
+    install_hooks(vault.root, "hyperresearch", platforms="opencode")
+
+    allowed = {"primary", "secondary", "accent", "success", "warning", "error", "info"}
+    agents_dir = vault.root / ".opencode" / "agents"
+
+    for agent_file in agents_dir.glob("*.md"):
+        body = agent_file.read_text(encoding="utf-8")
+        color_lines = [line for line in body.splitlines() if line.startswith("color:")]
+        assert len(color_lines) == 1, f"expected exactly one color line in {agent_file.name}"
+
+        color = color_lines[0].split(":", 1)[1].strip().strip('"').strip("'")
+        assert color in allowed or re.fullmatch(r"#[0-9a-fA-F]{6}", color), (
+            f"invalid color '{color}' in {agent_file.name}"
+        )
 
 
 def test_install_hooks_can_target_claude_only(tmp_path):

--- a/tests/test_core/test_opencode_models.py
+++ b/tests/test_core/test_opencode_models.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hyperresearch.core.opencode_models import resolve_opencode_model_choices
+
+
+def test_opencode_model_resolver_prefers_flat_rate_equivalent(tmp_path: Path, monkeypatch):
+    config_dir = tmp_path / "opencode"
+    config_dir.mkdir()
+    (config_dir / "opencode.json").write_text(
+        json.dumps(
+            {
+                "model": "anthropic/claude-sonnet-4-5",
+                "agent": {
+                    "build": {"model": "opencode-go/claude-sonnet-4-5"},
+                    "review": {"model": "anthropic/claude-opus-4-1"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HYPERRESEARCH_OPENCODE_CONFIG_DIR", str(config_dir))
+
+    choices = resolve_opencode_model_choices(tmp_path)
+
+    assert choices["sonnet"].model == "opencode-go/claude-sonnet-4-5"
+    assert choices["opus"].model == "anthropic/claude-opus-4-1"
+
+
+def test_opencode_model_resolver_uses_active_non_claude_roles(tmp_path: Path, monkeypatch):
+    config_dir = tmp_path / "opencode"
+    config_dir.mkdir()
+    (config_dir / "oh-my-openagent.json").write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "oracle": {"model": "openai/gpt-5.5", "variant": "xhigh"},
+                    "sisyphus": {"model": "opencode-go/kimi-k2.6"},
+                    "librarian": {
+                        "model": "opencode-go/minimax-m2.7",
+                        "fallback_models": [
+                            {"model": "opencode-go/minimax-m2.7-highspeed"},
+                            {"model": "openai/gpt-5.4-nano"},
+                        ],
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HYPERRESEARCH_OPENCODE_CONFIG_DIR", str(config_dir))
+
+    choices = resolve_opencode_model_choices(tmp_path)
+
+    assert choices["opus"].model == "openai/gpt-5.5"
+    assert choices["opus"].variant == "xhigh"
+    assert choices["sonnet"].model == "opencode-go/kimi-k2.6"
+    assert choices["haiku"].model == "opencode-go/minimax-m2.7-highspeed"
+
+
+def test_opencode_model_resolver_falls_back_without_active_models(tmp_path: Path, monkeypatch):
+    config_dir = tmp_path / "empty-opencode"
+    config_dir.mkdir()
+    monkeypatch.setenv("HYPERRESEARCH_OPENCODE_CONFIG_DIR", str(config_dir))
+
+    choices = resolve_opencode_model_choices(tmp_path)
+
+    assert choices["opus"].model.startswith("anthropic/claude-opus")
+    assert choices["sonnet"].model.startswith("anthropic/claude-sonnet")
+    assert choices["haiku"].model.startswith("anthropic/claude-haiku")

--- a/tests/test_core/test_vault.py
+++ b/tests/test_core/test_vault.py
@@ -68,6 +68,18 @@ def test_agent_docs_created(tmp_path: Path):
     assert "hyperresearch" in agents_content
 
 
+def test_init_can_target_opencode_docs_only(tmp_path: Path):
+    vault = Vault.init(tmp_path / "kb-opencode", platforms="opencode")
+    assert not (vault.root / "CLAUDE.md").exists()
+    assert (vault.root / "AGENTS.md").exists()
+
+
+def test_init_can_target_claude_docs_only(tmp_path: Path):
+    vault = Vault.init(tmp_path / "kb-claude", platforms="claude")
+    assert (vault.root / "CLAUDE.md").exists()
+    assert not (vault.root / "AGENTS.md").exists()
+
+
 def test_init_creates_claude_and_agents_md_only(tmp_path: Path):
     """Vault.init writes CLAUDE.md + AGENTS.md, but not other agent files."""
     vault = Vault.init(tmp_path / "kb-agent-docs")

--- a/tests/test_core/test_vault.py
+++ b/tests/test_core/test_vault.py
@@ -59,16 +59,19 @@ def test_config_loaded(tmp_vault: Vault):
 def test_agent_docs_created(tmp_path: Path):
     vault = Vault.init(tmp_path / "kb")
     assert (vault.root / "CLAUDE.md").exists()
-    content = (vault.root / "CLAUDE.md").read_text()
-    assert "hyperresearch" in content
+    assert (vault.root / "AGENTS.md").exists()
+
+    claude_content = (vault.root / "CLAUDE.md").read_text()
+    agents_content = (vault.root / "AGENTS.md").read_text()
+
+    assert "hyperresearch" in claude_content
+    assert "hyperresearch" in agents_content
 
 
-def test_init_only_creates_claude_md(tmp_path: Path):
-    """Vault.init writes CLAUDE.md ONLY — no AGENTS.md, GEMINI.md, or
-    .github/copilot-instructions.md. hyperresearch is Claude Code-only;
-    multi-platform doc generation was removed in v0.6."""
-    vault = Vault.init(tmp_path / "kb-claude-only")
+def test_init_creates_claude_and_agents_md_only(tmp_path: Path):
+    """Vault.init writes CLAUDE.md + AGENTS.md, but not other agent files."""
+    vault = Vault.init(tmp_path / "kb-agent-docs")
     assert (vault.root / "CLAUDE.md").exists()
-    assert not (vault.root / "AGENTS.md").exists()
+    assert (vault.root / "AGENTS.md").exists()
     assert not (vault.root / "GEMINI.md").exists()
     assert not (vault.root / ".github" / "copilot-instructions.md").exists()


### PR DESCRIPTION
## Summary
- add OpenCode AGENTS.md docs, native plugin hook generation, and OpenCode skills/agents output
- add model-resolution layer that maps hyperresearch opus/sonnet/haiku roles to active OpenCode provider/model IDs, preferring flat-rate equivalents
- add install platform selection so users can install Claude Code, OpenCode, or both via interactive checklist or --platform

## Verification
- .venv/bin/ruff check src tests
- .venv/bin/python -m pytest -q