### PR TITLE
feat: add Tavily web search provider alongside Exa

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
 [project.optional-dependencies]
 mcp = ["mcp>=1.6"]
 exa = ["exa-py>=2.0.0"]
-all = ["hyperresearch[mcp,exa]"]
+tavily = ["tavily-python>=0.3"]
+all = ["hyperresearch[mcp,exa,tavily]"]
 dev = [
     "pytest>=7.4",
     "pytest-cov>=4.1",

--- a/src/hyperresearch/web/base.py
+++ b/src/hyperresearch/web/base.py
@@ -166,4 +166,12 @@ def get_provider(
 
         return ExaProvider()
 
-    raise ValueError(f"Unknown web provider: {name!r}. Available: builtin, crawl4ai, exa")
+    if name == "tavily":
+        try:
+            from hyperresearch.web.tavily_provider import TavilyProvider
+
+            return TavilyProvider()
+        except ImportError:
+            raise ImportError("tavily provider requires: pip install \"hyperresearch[tavily]\"")
+
+    raise ValueError(f"Unknown web provider: {name!r}. Available: builtin, crawl4ai, exa, tavily")

--- a/src/hyperresearch/web/tavily_provider.py
+++ b/src/hyperresearch/web/tavily_provider.py
@@ -1,0 +1,104 @@
+"""Tavily web provider — search API designed for LLMs and AI agents.
+
+Tavily (https://tavily.com) provides web search and content extraction optimized
+for retrieval-augmented generation workflows.
+
+Configuration:
+    export TAVILY_API_KEY="tvly-your-api-key"   # https://app.tavily.com
+
+    # in .hyperresearch/config.toml
+    [web]
+    provider = "tavily"
+
+Optional install:
+    pip install "hyperresearch[tavily]"
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+from hyperresearch.web.base import WebResult
+
+
+class TavilyProvider:
+    """Web provider backed by the Tavily search API.
+
+    Supports both `search` (web search) and `fetch` (URL content extraction).
+    """
+
+    name = "tavily"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        search_depth: str = "advanced",
+        topic: str = "general",
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+    ):
+        try:
+            from tavily import TavilyClient
+        except ImportError as exc:
+            raise ImportError(
+                'tavily provider requires: pip install "hyperresearch[tavily]"'
+            ) from exc
+
+        key = api_key or os.environ.get("TAVILY_API_KEY", "").strip()
+        if not key:
+            raise RuntimeError(
+                "TAVILY_API_KEY is not set. Get a free key at "
+                "https://app.tavily.com and export it."
+            )
+
+        self._client = TavilyClient(api_key=key)
+        self._search_depth = search_depth
+        self._topic = topic
+        self._include_domains = include_domains
+        self._exclude_domains = exclude_domains
+
+    def search(self, query: str, max_results: int = 5) -> list[WebResult]:
+        """Search the web via Tavily and return ranked results with content."""
+        kwargs: dict[str, Any] = {
+            "max_results": max_results,
+            "search_depth": self._search_depth,
+            "topic": self._topic,
+        }
+        if self._include_domains:
+            kwargs["include_domains"] = self._include_domains
+        if self._exclude_domains:
+            kwargs["exclude_domains"] = self._exclude_domains
+
+        response = self._client.search(query, **kwargs)
+        return [_to_web_result(r) for r in response.get("results", [])]
+
+    def fetch(self, url: str) -> WebResult:
+        """Fetch a single URL via Tavily extract and return clean text."""
+        response = self._client.extract(urls=[url])
+        results = response.get("results", [])
+        if not results:
+            raise RuntimeError(f"Tavily returned no contents for {url}")
+        return _to_web_result(results[0])
+
+
+def _to_web_result(item: dict[str, Any]) -> WebResult:
+    """Convert a Tavily result dict into a hyperresearch WebResult."""
+    content = item.get("content", "") or item.get("raw_content", "") or ""
+
+    metadata: dict[str, Any] = {}
+    score = item.get("score")
+    if score is not None:
+        metadata["score"] = score
+    published_date = item.get("published_date")
+    if published_date:
+        metadata["published_date"] = published_date
+
+    return WebResult(
+        url=item.get("url", ""),
+        title=item.get("title", "") or "",
+        content=content,
+        fetched_at=datetime.now(UTC),
+        metadata=metadata,
+    )


### PR DESCRIPTION
## Summary

Adds Tavily as a selectable web search provider, parallel to the existing builtin, crawl4ai, and exa providers. Users can switch by setting `provider = "tavily"` in their `config.toml`.

### What changed

- **New file `src/hyperresearch/web/tavily_provider.py`**: Implements `TavilyProvider` class satisfying the `WebProvider` protocol. `search()` delegates to `TavilyClient.search()` and `fetch()` delegates to `TavilyClient.extract()`, mapping results to `WebResult`.
- **Modified `src/hyperresearch/web/base.py`**: Added `"tavily"` branch in `get_provider()` factory with ImportError guard. Updated the ValueError message to list tavily as an available option.
- **Modified `pyproject.toml`**: Added `tavily = ["tavily-python>=0.3"]` optional dependency and included it in the `all` extra.

### Dependency changes

- Added `tavily-python>=0.3` as optional dependency under `[project.optional-dependencies.tavily]`
- Extended `all` extra to include `hyperresearch[tavily]`

### Environment variable changes

- New: `TAVILY_API_KEY` — read by `TavilyProvider.__init__` (get a key at https://app.tavily.com)

### Notes for reviewers

- This is a strictly additive change — no existing provider code was modified
- Exa provider and `EXA_API_KEY` are untouched
- Pattern mirrors the existing `exa_provider.py` structure


### Automated Review

- Passed after 1 attempt(s)
- Final review: The additive Tavily migration is well-implemented and follows the existing codebase patterns closely. The `TavilyProvider` class mirrors the `ExaProvider` structure, uses correct Tavily SDK patterns (`TavilyClient.search()` returning a dict, `TavilyClient.extract()` for URL extraction), and the `_to_web_result` helper correctly handles both `content` (search) and `raw_content` (extract) field names from the Tavily API. The dependency is correctly added as an optional extra in `pyproject.toml`, the factory in `base.py` is updated consistently, and no existing functionality is touched. Two minor issues worth noting but not blocking.
