### PR TITLE
fix(web): engage patchright stealth by passing UndetectedAdapter to the crawler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pydantic>=2.0",
     "jinja2>=3.1",
     "platformdirs>=4.0",
-    "Crawl4AI>=0.4",
+    "Crawl4AI>=0.7.3",
     "pymupdf>=1.24",
     "httpx>=0.27",
 ]

--- a/src/hyperresearch/web/crawl4ai_provider.py
+++ b/src/hyperresearch/web/crawl4ai_provider.py
@@ -15,6 +15,8 @@ import sys
 from datetime import UTC, datetime
 
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, DefaultMarkdownGenerator
+from crawl4ai.async_crawler_strategy import AsyncPlaywrightCrawlerStrategy
+from crawl4ai.browser_adapter import UndetectedAdapter
 from crawl4ai.content_filter_strategy import PruningContentFilter
 
 from hyperresearch.web.base import WebResult
@@ -195,6 +197,23 @@ class Crawl4AIProvider:
             markdown_generator=self._md_generator,
         )
 
+    def _make_crawler(self) -> AsyncWebCrawler:
+        """Build an AsyncWebCrawler wired with the stealth (patchright) adapter.
+
+        crawl4ai's AsyncWebCrawler defaults to PlaywrightAdapter (plain
+        playwright); patchright/stealth only engages when an UndetectedAdapter is
+        passed via an explicit AsyncPlaywrightCrawlerStrategy. Without this the
+        provider's anti-bot behavior is only simulate_user + smart-wait. The
+        adapter's use_undetected flag is threaded through every BrowserManager
+        launch branch (default, persistent-context, and managed-browser/CDP), so
+        this is compatible with the authenticated-profile (user_data_dir) path.
+        """
+        strategy = AsyncPlaywrightCrawlerStrategy(
+            browser_config=self._browser_config,
+            browser_adapter=UndetectedAdapter(),
+        )
+        return AsyncWebCrawler(crawler_strategy=strategy, config=self._browser_config)
+
     def fetch(self, url: str) -> WebResult:
         # PDF detection: fetch directly with httpx, extract text with pymupdf
         if _is_pdf_url(url):
@@ -280,7 +299,7 @@ class Crawl4AIProvider:
         )
 
     async def _fetch_async(self, url: str) -> WebResult:
-        async with AsyncWebCrawler(config=self._browser_config) as crawler:
+        async with self._make_crawler() as crawler:
             result = await crawler.arun(url=url, config=self._run_config)
             metadata = result.metadata or {}
 
@@ -351,7 +370,7 @@ class Crawl4AIProvider:
 
         # Fetch HTML pages with browser
         if html_urls:
-            async with AsyncWebCrawler(config=self._browser_config) as crawler:
+            async with self._make_crawler() as crawler:
                 results = await crawler.arun_many(urls=html_urls, config=self._run_config)
                 for cr, url in zip(results, html_urls, strict=False):
                     if not cr.success:

--- a/tests/test_web/test_crawl4ai_stealth.py
+++ b/tests/test_web/test_crawl4ai_stealth.py
@@ -1,0 +1,49 @@
+"""Tests for the crawl4ai provider's stealth (patchright) wiring.
+
+Deterministic and offline: asserts the crawler is built with an explicit
+UndetectedAdapter so patchright engages. crawl4ai's AsyncWebCrawler otherwise
+defaults to PlaywrightAdapter (plain Playwright) and stealth never runs. No
+browser is launched — only in-memory object construction is exercised.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# crawl4ai is a core dependency, but guard so the suite degrades gracefully if a
+# minimal install lacks the browser_adapter API (introduced in crawl4ai 0.7.3).
+pytest.importorskip("crawl4ai.browser_adapter")
+
+from crawl4ai.async_crawler_strategy import AsyncPlaywrightCrawlerStrategy
+from crawl4ai.browser_adapter import UndetectedAdapter
+
+from hyperresearch.web.crawl4ai_provider import Crawl4AIProvider
+
+
+def test_make_crawler_uses_undetected_adapter() -> None:
+    """_make_crawler() must wire an UndetectedAdapter via AsyncPlaywrightCrawlerStrategy."""
+    crawler = Crawl4AIProvider(headless=True)._make_crawler()
+    strategy = crawler.crawler_strategy
+
+    assert isinstance(strategy, AsyncPlaywrightCrawlerStrategy)
+    assert isinstance(strategy.adapter, UndetectedAdapter)
+
+
+def test_browser_manager_marked_undetected() -> None:
+    """The adapter choice must propagate to BrowserManager.use_undetected.
+
+    This is the flag crawl4ai checks to import patchright instead of plain
+    playwright at launch — the actual engagement point.
+    """
+    crawler = Crawl4AIProvider(headless=True)._make_crawler()
+
+    assert crawler.crawler_strategy.browser_manager.use_undetected is True
+
+
+def test_undetected_wiring_survives_profile_path() -> None:
+    """The stealth adapter must also be wired when an authenticated profile
+    (user_data_dir / managed browser) is configured — the two are compatible."""
+    crawler = Crawl4AIProvider(headless=True, user_data_dir="/tmp/does-not-matter")._make_crawler()
+
+    assert isinstance(crawler.crawler_strategy.adapter, UndetectedAdapter)
+    assert crawler.crawler_strategy.browser_manager.use_undetected is True


### PR DESCRIPTION
Fixes #35.

### Problem

`Crawl4AIProvider` built `AsyncWebCrawler(config=...)` with no `crawler_strategy`, so crawl4ai used the default `PlaywrightAdapter` (plain Playwright) and patchright's stealth never engaged — the "stealth" was only `simulate_user` + smart-wait.

### Change

- Add a small `_make_crawler()` helper that builds an `AsyncWebCrawler` wired with an explicit `AsyncPlaywrightCrawlerStrategy(browser_adapter=UndetectedAdapter())`.
- Use it at both browser call sites (`_fetch_async`, `_fetch_many_async`).
- Bump the `Crawl4AI` floor `>=0.4` → `>=0.7.3` (the release that introduced `crawl4ai.browser_adapter` / `UndetectedAdapter`; the new import would otherwise fail on the old floor).
- Add offline tests for the wiring.

### Why it's safe with profiles

crawl4ai threads `use_undetected=isinstance(adapter, UndetectedAdapter)` into `BrowserManager`, which selects patchright across all launch branches (default, persistent-context `user_data_dir`, and managed-browser/CDP). The authenticated-profile path keeps working — covered by `test_undetected_wiring_survives_profile_path`.

### Reproduction (before / after)

Runtime driver module backing the crawler:

```
before (default adapter) -> playwright.async_api._generated   (plain Playwright)
after  (UndetectedAdapter) -> patchright.async_api._generated (stealth)
```

End-to-end, the patched provider renders a JS-heavy passive bot detector with webdriver signals suppressed (`webDriver` / `webDriverAdvanced` report "OK"). Note: headless still exposes `HeadlessChrome` in the UA — patchright-headless reduces passive detection but does not defeat interactive Cloudflare Turnstile challenges; that's unchanged and out of scope here.

### Tests

`tests/test_web/test_crawl4ai_stealth.py` (offline, no browser launch):
- `test_make_crawler_uses_undetected_adapter`
- `test_browser_manager_marked_undetected`
- `test_undetected_wiring_survives_profile_path`

### Verification

- `ruff check src/` → clean
- `ruff format --check` on the touched files → clean (repo-wide format left untouched to keep the diff focused)
- `python -m pytest tests/` → all pass

The diff is intentionally minimal — only the two call sites, the helper, the dependency floor, and the new test.