### PR TITLE
fix: make CI install what the tests import, and lock packaging metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -e ".[dev]"
+      - run: pip install -e ".[dev]" build
       - run: ruff check src/ tests/
       - run: pytest tests/ -v
+      - run: python -m build --outdir /tmp/hyperresearch-dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,14 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install build tools
-        run: pip install build
+      - name: Install test and build tools
+        run: pip install -e ".[dev]" build
+
+      - name: Lint
+        run: ruff check src/ tests/
+
+      - name: Test
+        run: pytest tests/ -v
 
       - name: Build package
         run: python -m build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Release readiness and deployability
+
+- **Version metadata is consistent again.** `hyperresearch.__version__` now tracks the version declared in `pyproject.toml`, fixing the state where the built wheel reported `0.8.6` while `hyperresearch --version` reported `0.8.5`.
+- **CI installs the dependencies used by the tests.** The `dev` extra now includes `exa-py`, so the Exa provider tests pass under the same `pip install -e ".[dev]"` command CI runs. Without it, `main` fails 10 tests in `tests/test_web/test_exa_provider.py` with `ModuleNotFoundError: No module named 'exa_py'`.
+- **Optional extras match CLI guidance.** Declared the `crawl4ai` and `watch` extras the CLI already directs users to install. `pip install hyperresearch[watch]` previously resolved to no extra and installed no `watchdog`, so `hpr watch` stayed broken while telling the user to run the command that had just failed.
+- **Publish workflow now gates on lint and tests before building.** Tagged releases still publish via trusted PyPI publishing, but the publish job now fails before upload if ruff or pytest fails.
+- **Packaging regression tests added.** The test suite now checks that runtime version metadata tracks `pyproject.toml` and that dev/install extras cover the tested optional provider surface.
+
 ## [0.8.6] - 2026-05-14
 
 ### Run-to-run safety: no more silent overwrites between /hyperresearch sessions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,20 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+crawl4ai = ["Crawl4AI>=0.4"]
 mcp = ["mcp>=1.6"]
 exa = ["exa-py>=2.0.0"]
-all = ["hyperresearch[mcp,exa]"]
+watch = ["watchdog>=4.0"]
+all = ["hyperresearch[crawl4ai,mcp,exa,watch]"]
 dev = [
     "pytest>=7.4",
     "pytest-cov>=4.1",
     "ruff>=0.3",
     "mypy>=1.8",
+    "exa-py>=2.0.0",
+    "mcp>=1.6",
+    "types-PyYAML>=6.0.12",
+    "watchdog>=4.0",
 ]
 
 [project.scripts]

--- a/src/hyperresearch/__init__.py
+++ b/src/hyperresearch/__init__.py
@@ -1,3 +1,3 @@
 """Hyperresearch — agent-driven research knowledge base."""
 
-__version__ = "0.8.5"
+__version__ = "0.8.6"

--- a/tests/test_core/test_packaging.py
+++ b/tests/test_core/test_packaging.py
@@ -1,0 +1,31 @@
+"""Packaging and release metadata regression tests."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import hyperresearch
+
+
+def _pyproject() -> dict:
+    root = Path(__file__).resolve().parents[2]
+    with (root / "pyproject.toml").open("rb") as f:
+        return tomllib.load(f)
+
+
+def test_runtime_version_matches_project_metadata():
+    """The CLI version comes from __version__, so it must track package metadata."""
+    project = _pyproject()["project"]
+    assert hyperresearch.__version__ == project["version"]
+
+
+def test_dev_extra_covers_tested_optional_providers():
+    """CI installs only .[dev], so dev must include optional providers tested by pytest."""
+    optional = _pyproject()["project"]["optional-dependencies"]
+    dev_deps = set(optional["dev"])
+
+    assert "exa-py>=2.0.0" in dev_deps
+    assert "exa" in optional
+    assert "crawl4ai" in optional
+    assert "watch" in optional


### PR DESCRIPTION
## Why

`main` has failed CI since `c9abce7` (2026-05-14). The Exa provider tests import `exa_py`, but CI installs only `.[dev]`, which doesn't include it — so `tests/test_web/test_exa_provider.py` fails 10 of its 12 tests with `ModuleNotFoundError: No module named 'exa_py'` ([run 25879578650](https://github.com/jordan-gibbs/hyperresearch/actions/runs/25879578650)). The other 2 pass because they mock the `ImportError` path.

While fixing that, two smaller user-facing issues surfaced:

**The published wheel misreports its own version.** `pip install hyperresearch==0.8.6` gives you a CLI that prints `hyperresearch v0.8.5`, because `__init__.py` was left at `0.8.5` when `pyproject.toml` moved to `0.8.6`. This is live on PyPI today.

**`pip install hyperresearch[watch]` is a dead end.** The `watch` extra was never declared and `watchdog` is in no dependency list, so that command matches no extra and installs nothing — then `hpr watch` fails with an ImportError whose message tells you to run the command that just failed (`src/hyperresearch/cli/watch.py:21`). Same for `hyperresearch[crawl4ai]`, referenced in three places (`web/base.py:162`, `cli/setup.py:67`, `cli/install.py:172`), though that one is harmless since `Crawl4AI` is already a base dependency.

## What changed

- **`dev` extra now includes `exa-py`**, so `pip install -e ".[dev]"` — the exact command CI runs — installs what the suite imports. Also added `mcp`, `watchdog`, and `types-PyYAML`.
- **Declared the `crawl4ai` and `watch` extras** the CLI already directs users to.
- **Fixed the version skew**: both `pyproject.toml` and `__init__.py` now read `0.8.6`.
- **Added `tests/test_core/test_packaging.py`** so both failure modes stay fixed: runtime `__version__` must track `pyproject.toml`, and `dev` must cover the optional providers the suite imports.
- **`publish.yml` now runs ruff and pytest before building**, so a tagged release can't reach PyPI without passing the same checks as CI. `ci.yml` also proves the package still builds.

## On versioning

I deliberately **did not bump the version** — that's your call. The changelog entry sits under `## [Unreleased]` so you can rename it to whatever you cut next.

## Verification

Ran your CI workflow locally against the full declared support matrix (`>=3.11,<3.14`):

| Python | install | ruff | pytest | build |
|---|---|---|---|---|
| 3.11.13 | pass | pass | 193 passed | pass |
| 3.12.11 | pass | pass | 193 passed | pass |
| 3.13.11 | pass | pass | 193 passed | pass |

The 12 Exa tests are collected and executed, not skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)