### PR TITLE
fix: mechanical ship gate (run finish) after Q62 shipped past both prose gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Ship gate enforcement: `run finish` (lessons from the first premier run)
+
+The first end-to-end premier benchmark run exposed both prose-only gates failing exactly the way prose gates fail: the orchestrator never invoked `run verify` (a 25,647-word report shipped against a 16K ceiling), and when lint flagged 24 hallucinated/mangled quotes it wrote itself a "false positives" memo and shipped anyway.
+
+- **`hpr run finish <tag>`** is the new terminal gate and the ONLY path to manifest status `done`. It runs the full verification battery and flips the run to `done` on pass or `blocked (verify)` on fail, recording the verdict in the manifest either way. The router's final gate now centers on it, with explicit no-override language (gate errors are fixed by changing the report, never re-interpreted), a bounded 3-round fix loop, and a new invariant: a run is complete only when `finish` reports `passed: true`.
+- **`verify_run` now includes the blocking content lints** (`quote-integrity`, `retracted-citations`) in-process, so one command carries the whole verdict and there is no seam where a failing rule can be run separately and argued with.
+- **Length enforcement moved upstream too.** Step 11 gains a mechanical word-count gate with the one permitted fix (a single synthesizer compression respawn, cheapest at that moment); the synthesizer's word-target table is now rendered from the profile (it was hardcoded to full-gear numbers, so premier's 8-16K target never reached the prompt) with the high end stated as a hard ceiling; the polish auditor strips quotation marks from non-verbatim rhetorical framing before the gate ever sees them.
+
 ### Per-agent models are now real config; dollar-cost claims removed
 
 - **ModelMap wired into agent rendering.** The profile's per-agent model map existed but was decorative — every installed agent's `model:` frontmatter line was hardcoded in `hooks.py`, so overriding models via a profile silently did nothing. All 16 agent templates now carry `model: << p.models.X >>`, rendered from the profile at install time, and `ModelMap` gained the two missing agents (`cite_checker`, `browser_fetcher`) plus validation (non-empty; aliases or full model IDs both accepted). Full flexibility per agent: `[profile.full]` + `models = { fetcher = "haiku" }` swaps every fetcher to Haiku on the next install/`profile use`; unspecified agents keep their defaults. Defaults are unchanged (verified byte-identical by the goldens).

--- a/src/hyperresearch/cli/run_cmd.py
+++ b/src/hyperresearch/cli/run_cmd.py
@@ -434,3 +434,47 @@ def run_verify(
         console.print("[green]PASSED[/]" if result["passed"] else "[red]FAILED[/]")
     if not result["passed"]:
         raise typer.Exit(1)
+
+
+@app.command("finish")
+def run_finish(
+    vault_tag: str | None = typer.Argument(None, help="Run tag (default: newest run)"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="JSON output"),
+) -> None:
+    """Terminal ship gate: verify the run, then flip the manifest.
+
+    Pass -> status "done". Fail -> status "blocked" (blocked_on: verify),
+    exit 1. This is the ONLY way a run reaches "done"; the fix for a failed
+    gate is changing the report until the gate passes, never re-running the
+    checks by hand and re-interpreting the results.
+    """
+    from hyperresearch.core.runs import RunError, finish_run
+
+    vault = _vault_or_exit(json_output)
+    tag = _resolve_tag(vault, vault_tag, json_output)
+    try:
+        result = finish_run(vault, tag)
+    except RunError as e:
+        if json_output:
+            output(error(str(e), "RUN_ERROR"), json_mode=True)
+        else:
+            console.print(f"[red]Error:[/] {e}")
+        raise typer.Exit(1)
+
+    verify = result["verify"]
+    if json_output:
+        output(success(result, vault=str(vault.root)), json_mode=True)
+    else:
+        for c in verify["checks"]:
+            mark = "[green]ok[/]" if c["ok"] else "[red]FAIL[/]"
+            console.print(f"  {mark} {c['name']}: {c['detail']}")
+        status = result["manifest"]["status"]
+        if verify["passed"]:
+            console.print(f"[green]SHIPPED[/] — run status: {status}")
+        else:
+            console.print(
+                f"[red]BLOCKED[/] — run status: {status} (blocked_on: verify). "
+                "Fix the report, then run finish again."
+            )
+    if not verify["passed"]:
+        raise typer.Exit(1)

--- a/src/hyperresearch/core/hooks.py
+++ b/src/hyperresearch/core/hooks.py
@@ -1461,6 +1461,13 @@ Also strip:
 - Literal prompt echoes ("User prompt:", "The query is:", etc.)
 - Leftover backticks around section headings
 - Stray "Here is the report:" / "Below is the draft:" preamble lines
+- **Non-verbatim quotation marks.** Quotation marks are reserved for text
+  quoted VERBATIM from a source. Rhetorical framing, paraphrase, imagined
+  objections, and the report's own coinages ("the scaling wall", "a chip
+  cannot hold enough ions") must NOT be wrapped in quotation marks —
+  rewrite as plain prose or italics. The ship gate mechanically rejects
+  any quoted span it cannot find verbatim in the vault, so every
+  decorative quote you leave is a guaranteed gate failure.
 - **Citation pass-through.** Leave all `[N]` inline citations and the
   Sources/References section exactly as the drafter wrote them.
   Citations are a product feature, not a polish target.
@@ -2050,11 +2057,19 @@ permitted to be uneven — pass 2 cleans it up. Goals for pass 1:
 Pass 1 length target: in the response_format range, leaning slightly long
 (15-20% over target). Pass 2 cuts.
 
-| `response_format` | Pass 1 target | Pass 2 final target |
-|---|---|---|
-| `"short"` | 600-2400 words | 500-2000 words |
-| `"structured"` | 2400-6000 words | 2000-5000 words |
-| `"argumentative"` | 6000-12000 words | 5000-10000 words |
+| `response_format` | Pass 2 final target (the high end is a HARD ceiling) |
+|---|---|
+| `"short"` | << p.word_targets["short"]|hyphen >> words |
+| `"structured"` | << p.word_targets["structured"]|hyphen >> words |
+| `"argumentative"` | << p.word_targets["argumentative"]|hyphen >> words |
+
+The ceiling is mechanical, not stylistic: the pipeline's ship gate fails
+any report more than 20% over the high end, and the only remedy at that
+point is a forced compression rewrite of your own output. Count your words
+before finishing pass 2; if you are over the ceiling, cut until you are
+under it. A large corpus is never a reason to exceed the ceiling —
+selectivity is the skill being graded, and burying the argument under
+every available source scores WORSE on insight, not better.
 
 When pass 1 is done, write it to `pass1_output_path`.
 

--- a/src/hyperresearch/core/runs.py
+++ b/src/hyperresearch/core/runs.py
@@ -401,6 +401,36 @@ def verify_run(vault, vault_tag: str) -> dict:
             "scaffold gospel header must not ship",
         )
 
+        # Content gates: the blocking lint rules run in-process, so this ONE
+        # command carries the whole ship verdict. Bench Q62 shipped with 24
+        # hallucinated-quote errors because the orchestrator ran the lint
+        # separately and re-interpreted the failures as false positives —
+        # folding the rules in here removes that seam.
+        try:
+            from hyperresearch.cli.lint import (
+                _check_quote_integrity,
+                _check_retracted_citations,
+            )
+
+            for rule, fn in (
+                ("quote-integrity", _check_quote_integrity),
+                ("retracted-citations", _check_retracted_citations),
+            ):
+                errors = [
+                    i for i in fn(vault, vault.db, report_path, report_text)
+                    if i.get("severity") == "error"
+                ]
+                check(
+                    rule,
+                    not errors,
+                    "clean" if not errors else (
+                        f"{len(errors)} error(s) — first: "
+                        f"{errors[0].get('message', '')[:160]}"
+                    ),
+                )
+        except Exception as exc:
+            check("content-lints", False, f"content lint rules failed to run: {exc}")
+
     # Tier-mandated artifacts
     steps = set(manifest.get("profile_steps", []))
     if {"12", "14"} <= steps:
@@ -433,3 +463,35 @@ def verify_run(vault, vault_tag: str) -> dict:
         check("cite-check-resolved", ok, detail)
 
     return {"vault_tag": vault_tag, "passed": all(c["ok"] for c in checks), "checks": checks}
+
+
+def finish_run(vault, vault_tag: str) -> dict:
+    """The terminal ship gate: verify, then flip the manifest accordingly.
+
+    This is the ONLY path to status "done". Verification failure flips the
+    run to blocked (blocked_on="verify") instead — the caller's job is then
+    to change the REPORT until the gate passes, never to re-interpret the
+    checks. The verify result is recorded in the manifest either way, so
+    `run status` and the bench harness can see whether a "done" run actually
+    earned it.
+    """
+    result = verify_run(vault, vault_tag)
+    manifest = load_manifest(vault, vault_tag)
+    manifest["verify"] = {
+        "passed": result["passed"],
+        "at": _now(),
+        "failed_checks": [c["name"] for c in result["checks"] if not c["ok"]],
+    }
+    if result["passed"]:
+        manifest["status"] = "done"
+        manifest["blocked_on"] = None
+    else:
+        manifest["status"] = "blocked"
+        manifest["blocked_on"] = "verify"
+    _save(vault, vault_tag, manifest)
+    record_event(vault, vault_tag, {
+        "type": "finish",
+        "passed": result["passed"],
+        "failed_checks": manifest["verify"]["failed_checks"],
+    })
+    return {"manifest": manifest, "verify": result}

--- a/src/hyperresearch/core/runs.py
+++ b/src/hyperresearch/core/runs.py
@@ -452,6 +452,10 @@ def verify_run(vault, vault_tag: str) -> dict:
         if ok:
             try:
                 findings = json.loads(cc_findings.read_text(encoding="utf-8-sig"))
+                # The cite-check step writes {"findings": [...]}; older runs
+                # (and the original design sketch) used a bare list. Accept both.
+                if isinstance(findings, dict):
+                    findings = findings.get("findings", [])
                 criticals = [f for f in findings if f.get("severity") == "critical"]
                 if criticals:
                     log_path = run_dir / "cite-check-patch-log.json"

--- a/src/hyperresearch/skills/hyperresearch-11-synthesize.md
+++ b/src/hyperresearch/skills/hyperresearch-11-synthesize.md
@@ -218,14 +218,16 @@ When the synthesizer returns:
    - Sections flagged as still weak
 
 3. **Sanity checks on the final report:**
-   - Length is in the target range for `response_format` (not 3x)
+   - **LENGTH GATE (mechanical, not a judgment call):** count the words (`wc -w` or python). The profile ceiling for the response_format is a HARD limit — the ship gate (`run finish`) fails any report more than 20% over target, so an over-long report here is guaranteed rework later. Check it now, when fixing is cheapest.
    - Has all H2s from `required_section_headings`
    - Citations match `citation_style`: `[[note-id]]` markers for `"wikilink"` (no Sources section); `[N]` markers + a `## Sources` section for `"inline"`; no markers for `"none"`
    - No YAML frontmatter, no scaffold leaks, no pipeline vocabulary
 
 If pass 2 is longer than pass 1 (positive delta), something went wrong — pass 2 is supposed to cut. Investigate before proceeding.
 
-If a sanity check fails, hand-craft an Edit on `research/notes/final_report_<vault_tag>.md` yourself to fix it. Do NOT re-spawn the synthesizer — that's regeneration, which violates the patch-not-regenerate invariant once we have a final draft.
+**If the length gate fails (word count above the target high):** re-spawn the synthesizer ONCE for a compression pass — input is its own final report, directive is "cut to <middle of target range> words: collapse redundant sections, cut the weakest evidence per point, keep every load-bearing claim and citation." This is the ONE permitted regeneration, because the write-once invariant starts only after this step's exit criteria pass; length violations discovered later can only be fixed by exactly this move at higher cost.
+
+If any other sanity check fails, hand-craft an Edit on `research/notes/final_report_<vault_tag>.md` yourself to fix it. Do NOT re-spawn the synthesizer for non-length issues — that's regeneration, which violates the patch-not-regenerate invariant once we have a final draft.
 
 ---
 
@@ -237,7 +239,7 @@ After this step, the final report is only modified by Edit hunks from the patche
 
 ## Exit criterion
 
-- `research/notes/final_report_<vault_tag>.md` exists, length in target range
+- `research/notes/final_report_<vault_tag>.md` exists, **word count verified ≤ target high** (counted mechanically, not estimated)
 - `research/runs/<vault_tag>/temp/synthesis-pass1.md` exists (debugging artifact)
 - All H2s from `required_section_headings` present
 - Citations match `citation_style` (wikilink → `[[note-id]]` no Sources section; inline → `[N]` + Sources section; none → no markers)

--- a/src/hyperresearch/skills/hyperresearch-15-polish.md
+++ b/src/hyperresearch/skills/hyperresearch-15-polish.md
@@ -132,6 +132,8 @@ If any artifact is missing, the responsible step failed silently. Re-spawn the r
    - `scaffold-prompt`: scaffold's User Prompt section doesn't match the query file exactly — fix the scaffold
    - `patch-surgery`: draft churn from step 11 → final exceeds the safety threshold — read the patch log and investigate
 
+   These four rules are pre-checks. The BINDING gate is `$HPR run finish <vault_tag>` in the router's final phase — it re-runs the battery (including quote-integrity and retracted-citations) and refuses to mark the run done while any check fails. Gate errors are facts about the report, not opinions to assess: never classify a gate error as a false positive. In particular, quotation marks are reserved for verbatim source text — the fix for a flagged rhetorical/framing quote is removing its quotation marks, not a memo explaining why it's fine.
+
 ---
 
 ## Step 15.6 — Ship

--- a/src/hyperresearch/skills/hyperresearch.md
+++ b/src/hyperresearch/skills/hyperresearch.md
@@ -223,20 +223,24 @@ done
 
 (Light tier skips critics + patcher entirely — the critic-findings and patch-log files won't exist. That's expected; only `polish-log.json` is required for light.)
 
-Then run the verification battery + lint:
+Then refresh retraction data and run the SHIP GATE:
 ```bash
-$HPR run verify <vault_tag> --json          # structural: headings, length, citation density, artifacts, cite-check resolution
 $HPR sources retractions --tag <vault_tag> --json   # ship-time retraction re-check (bypasses cache)
-$HPR lint --rule wrapper-report --json
-$HPR lint --rule locus-coverage --json
-$HPR lint --rule scaffold-prompt --json
-$HPR lint --rule patch-surgery --json
-$HPR lint --rule quote-integrity --json     # every quoted span must exist verbatim in a vault note
-$HPR lint --rule retracted-citations --json # retracted sources cited unmarked block the ship
-$HPR lint --rule numeric-consistency --json # warnings: numbers untraceable to evidence — verify or remove
+$HPR run finish <vault_tag> --json                  # THE ship gate: verify + manifest flip
 ```
 
-If `run verify` fails or any rule returns `error` severity issues, address them before declaring complete. Then ship: the final report lives at `research/notes/final_report_<vault_tag>.md`.
+`run finish` runs the whole verification battery — report exists, required headings, **length within the profile's word target (±20%)**, citation density, tier artifacts, cite-check resolution, **quote-integrity**, and **retracted-citations** — and flips the manifest to `done` only when every check passes. On failure it flips the run to `blocked (verify)` and exits 1.
+
+**The gate's verdict is final. You may not re-run individual rules and re-classify their errors as false positives.** If a check fails, change the REPORT until the gate passes:
+
+- `length-in-range` over the ceiling → spawn the synthesizer for ONE compression pass (its own output as input, target = middle of the word range). Do not re-run the critics afterward — go straight back to `run finish`.
+- `quote-integrity` → quotation marks are reserved for verbatim source text. Rhetorical or framing "quotes" lose their quotation marks (rewrite as plain or italicized prose via Edit); real quotes get fixed to verbatim or cut.
+- `retracted-citations` → acknowledge the retraction in the sentence or remove the citation.
+- Anything else → fix the specific artifact the check names.
+
+Re-run `$HPR run finish <vault_tag> --json` after each fix round. Maximum 3 rounds; if the gate still fails, leave the run `blocked` and report the failing checks to the user honestly — a blocked run with a true manifest beats a shipped report that lies. Optional advisory: `$HPR lint --rule numeric-consistency --json` (warnings only, never blocks).
+
+Ship only after `run finish` reports `"passed": true`: the final report lives at `research/notes/final_report_<vault_tag>.md`.
 
 ---
 
@@ -255,6 +259,7 @@ If `run verify` fails or any rule returns `error` severity issues, address them 
 11. **Step 11 synthesis is MANDATORY for `full` tier.** The synthesizer subagent (Read+Write tool-locked) writes the final report from the 3 drafts. The orchestrator does NOT write the final report itself for these tiers.
 12. **Subagents read full source text.** Draft sub-orchestrators MUST batch-read every note in their `must_read_note_ids` list before writing. Fetchers MUST chase 3-8 primary sources via citation chains.
 13. **NEVER emit a bare text response while subagent tasks are in flight.**
+14. **A run is complete ONLY when `run finish` reports `passed: true`.** Gate failures are fixed by changing the report, never by re-interpreting, downgrading, or memo-ing away the checks. If 3 fix rounds don't clear the gate, the run stays `blocked` and you say so.
 
 ---
 

--- a/tests/fixtures/golden_prompts/skills/hyperresearch.md
+++ b/tests/fixtures/golden_prompts/skills/hyperresearch.md
@@ -223,20 +223,24 @@ done
 
 (Light tier skips critics + patcher entirely — the critic-findings and patch-log files won't exist. That's expected; only `polish-log.json` is required for light.)
 
-Then run the verification battery + lint:
+Then refresh retraction data and run the SHIP GATE:
 ```bash
-$HPR run verify <vault_tag> --json          # structural: headings, length, citation density, artifacts, cite-check resolution
 $HPR sources retractions --tag <vault_tag> --json   # ship-time retraction re-check (bypasses cache)
-$HPR lint --rule wrapper-report --json
-$HPR lint --rule locus-coverage --json
-$HPR lint --rule scaffold-prompt --json
-$HPR lint --rule patch-surgery --json
-$HPR lint --rule quote-integrity --json     # every quoted span must exist verbatim in a vault note
-$HPR lint --rule retracted-citations --json # retracted sources cited unmarked block the ship
-$HPR lint --rule numeric-consistency --json # warnings: numbers untraceable to evidence — verify or remove
+$HPR run finish <vault_tag> --json                  # THE ship gate: verify + manifest flip
 ```
 
-If `run verify` fails or any rule returns `error` severity issues, address them before declaring complete. Then ship: the final report lives at `research/notes/final_report_<vault_tag>.md`.
+`run finish` runs the whole verification battery — report exists, required headings, **length within the profile's word target (±20%)**, citation density, tier artifacts, cite-check resolution, **quote-integrity**, and **retracted-citations** — and flips the manifest to `done` only when every check passes. On failure it flips the run to `blocked (verify)` and exits 1.
+
+**The gate's verdict is final. You may not re-run individual rules and re-classify their errors as false positives.** If a check fails, change the REPORT until the gate passes:
+
+- `length-in-range` over the ceiling → spawn the synthesizer for ONE compression pass (its own output as input, target = middle of the word range). Do not re-run the critics afterward — go straight back to `run finish`.
+- `quote-integrity` → quotation marks are reserved for verbatim source text. Rhetorical or framing "quotes" lose their quotation marks (rewrite as plain or italicized prose via Edit); real quotes get fixed to verbatim or cut.
+- `retracted-citations` → acknowledge the retraction in the sentence or remove the citation.
+- Anything else → fix the specific artifact the check names.
+
+Re-run `$HPR run finish <vault_tag> --json` after each fix round. Maximum 3 rounds; if the gate still fails, leave the run `blocked` and report the failing checks to the user honestly — a blocked run with a true manifest beats a shipped report that lies. Optional advisory: `$HPR lint --rule numeric-consistency --json` (warnings only, never blocks).
+
+Ship only after `run finish` reports `"passed": true`: the final report lives at `research/notes/final_report_<vault_tag>.md`.
 
 ---
 
@@ -255,6 +259,7 @@ If `run verify` fails or any rule returns `error` severity issues, address them 
 11. **Step 11 synthesis is MANDATORY for `full` tier.** The synthesizer subagent (Read+Write tool-locked) writes the final report from the 3 drafts. The orchestrator does NOT write the final report itself for these tiers.
 12. **Subagents read full source text.** Draft sub-orchestrators MUST batch-read every note in their `must_read_note_ids` list before writing. Fetchers MUST chase 3-8 primary sources via citation chains.
 13. **NEVER emit a bare text response while subagent tasks are in flight.**
+14. **A run is complete ONLY when `run finish` reports `passed: true`.** Gate failures are fixed by changing the report, never by re-interpreting, downgrading, or memo-ing away the checks. If 3 fix rounds don't clear the gate, the run stays `blocked` and you say so.
 
 ---
 

--- a/tests/test_core/test_prompt_golden.py
+++ b/tests/test_core/test_prompt_golden.py
@@ -48,6 +48,12 @@ Deliberate deviations already folded into the goldens (2026-07-19):
     column, gap-fetch's "+$1-3 per run" became fetcher-count overhead
     framing, the source-analyst's "$2-5 per spawn" block became "Effort
     discipline", and its Sonnet-1M context claims became model-neutral).
+  - Ship-gate enforcement (2026-07-19, after bench Q62 shipped a 25.6K-word
+    report with 24 hallucinated-quote lint errors "assessed as false
+    positives"): the router's final gate now centers on `run finish` (verify
+    + manifest flip, no-override language, bounded fix loop) instead of the
+    advisory verify+lint checklist, and invariant 14 makes `passed: true`
+    the only definition of complete.
 """
 
 from __future__ import annotations

--- a/tests/test_core/test_verification.py
+++ b/tests/test_core/test_verification.py
@@ -382,6 +382,31 @@ class TestFinishGate:
         assert "quote-integrity" in names
         assert "retracted-citations" in names
 
+    def test_cite_check_findings_accepts_both_shapes(self, tmp_vault):
+        """The pipeline writes {"findings": [...]}; verify must not crash on
+        it (it did, on the first live gate run) and must still resolve
+        criticals for the bare-list shape."""
+        from hyperresearch.core.runs import set_step
+
+        for tag, payload in (
+            ("fin-07", {"findings": [{"severity": "critical", "verdict": "unsupported"}]}),
+            ("fin-08", [{"severity": "critical", "verdict": "unsupported"}]),
+        ):
+            self._well_formed_light_run(tmp_vault, tag)
+            run_dir = tmp_vault.run_dir(tag)
+            set_step(tmp_vault, tag, "14.5", "done")
+            (run_dir / "cite-check-findings.json").write_text(
+                json.dumps(payload), encoding="utf-8"
+            )
+            result = verify_run(tmp_vault, tag)  # must not raise
+            by_name = {c["name"]: c for c in result["checks"]}
+            # A critical finding with no patch log fails the check cleanly.
+            assert by_name["cite-check-resolved"]["ok"] is False
+            (run_dir / "cite-check-patch-log.json").write_text("[]", encoding="utf-8")
+            result = verify_run(tmp_vault, tag)
+            by_name = {c["name"]: c for c in result["checks"]}
+            assert by_name["cite-check-resolved"]["ok"] is True
+
 
 class TestCiteCheckerAgentInstall:
     def test_agent_installs(self, tmp_vault):

--- a/tests/test_core/test_verification.py
+++ b/tests/test_core/test_verification.py
@@ -275,6 +275,114 @@ class TestTelemetryAndVerify:
         assert r.exit_code == 1  # no report -> fail
 
 
+class TestFinishGate:
+    """`run finish` is the terminal gate: it must be impossible to reach
+    status "done" past a failing check, and the two Q62 failure modes
+    (hallucinated quotes assessed away, length gate never run) must now be
+    mechanically blocking."""
+
+    def _well_formed_light_run(self, tmp_vault, tag: str, body: str | None = None):
+        init_run(tmp_vault, tag, profile="light")
+        run_dir = tmp_vault.run_dir(tag)
+        (run_dir / "prompt-decomposition.json").write_text(json.dumps({
+            "response_format": "short",
+            "required_section_headings": ["## Findings"],
+        }), encoding="utf-8")
+        (run_dir / "polish-log.json").write_text('{"applied": []}', encoding="utf-8")
+        report = tmp_vault.root / "research" / "notes" / f"final_report_{tag}.md"
+        if body is None:
+            body = "## Findings\n\n" + (
+                "Substantive sentence with real evidence attached [[src-note]]. " * 80
+            )
+        report.write_text(body, encoding="utf-8")
+        return report
+
+    def test_finish_marks_clean_run_done(self, tmp_vault):
+        from hyperresearch.core.runs import finish_run, load_manifest
+
+        self._well_formed_light_run(tmp_vault, "fin-01")
+        result = finish_run(tmp_vault, "fin-01")
+        assert result["verify"]["passed"] is True
+        manifest = load_manifest(tmp_vault, "fin-01")
+        assert manifest["status"] == "done"
+        assert manifest["blocked_on"] is None
+        assert manifest["verify"]["passed"] is True
+        assert manifest["verify"]["failed_checks"] == []
+
+    def test_finish_blocks_hallucinated_quote(self, tmp_vault):
+        from hyperresearch.core.runs import finish_run, load_manifest
+
+        body = "## Findings\n\n" + (
+            "Substantive sentence with real evidence attached [[src-note]]. " * 80
+        ) + '\n\nAs one expert put it, "this quotation was never fetched into any vault note anywhere."\n'
+        self._well_formed_light_run(tmp_vault, "fin-02", body=body)
+        result = finish_run(tmp_vault, "fin-02")
+        assert result["verify"]["passed"] is False
+        by_name = {c["name"]: c for c in result["verify"]["checks"]}
+        assert by_name["quote-integrity"]["ok"] is False
+        manifest = load_manifest(tmp_vault, "fin-02")
+        assert manifest["status"] == "blocked"
+        assert manifest["blocked_on"] == "verify"
+        assert "quote-integrity" in manifest["verify"]["failed_checks"]
+
+    def test_finish_blocks_over_length_report(self, tmp_vault):
+        from hyperresearch.core.runs import finish_run, load_manifest
+
+        # light/short target is 500-2000 words; 20% tolerance caps at 2400.
+        body = "## Findings\n\n" + (
+            "Substantive sentence with real evidence attached [[src-note]]. " * 500
+        )
+        self._well_formed_light_run(tmp_vault, "fin-03", body=body)
+        result = finish_run(tmp_vault, "fin-03")
+        assert result["verify"]["passed"] is False
+        by_name = {c["name"]: c for c in result["verify"]["checks"]}
+        assert by_name["length-in-range"]["ok"] is False
+        manifest = load_manifest(tmp_vault, "fin-03")
+        assert manifest["status"] == "blocked"
+        assert manifest["blocked_on"] == "verify"
+
+    def test_finish_then_fix_then_done(self, tmp_vault):
+        """The intended loop: blocked -> fix the report -> finish passes."""
+        from hyperresearch.core.runs import finish_run, load_manifest
+
+        body = "## Findings\n\n" + (
+            "Substantive sentence with real evidence attached [[src-note]]. " * 80
+        ) + '\n\nAs one expert put it, "this quotation was never fetched into any vault note anywhere."\n'
+        report = self._well_formed_light_run(tmp_vault, "fin-04", body=body)
+        assert finish_run(tmp_vault, "fin-04")["verify"]["passed"] is False
+
+        # The prescribed fix: drop the quotation marks, not the gate.
+        fixed = report.read_text(encoding="utf-8").replace(
+            '"this quotation was never fetched into any vault note anywhere."',
+            "this claim stands as the report's own framing.",
+        )
+        report.write_text(fixed, encoding="utf-8")
+        assert finish_run(tmp_vault, "fin-04")["verify"]["passed"] is True
+        assert load_manifest(tmp_vault, "fin-04")["status"] == "done"
+
+    def test_finish_cli_exit_code(self, tmp_vault, monkeypatch):
+        from typer.testing import CliRunner
+
+        from hyperresearch.cli import app
+
+        init_run(tmp_vault, "fin-05", profile="light")
+        monkeypatch.chdir(tmp_vault.root)
+        r = CliRunner().invoke(app, ["run", "finish", "fin-05", "--json"])
+        assert r.exit_code == 1  # no report -> gate fails -> blocked
+        from hyperresearch.core.runs import load_manifest
+
+        assert load_manifest(tmp_vault, "fin-05")["status"] == "blocked"
+
+    def test_verify_includes_content_gates(self, tmp_vault):
+        """verify_run itself must carry quote-integrity + retracted-citations
+        checks — one command, whole verdict."""
+        self._well_formed_light_run(tmp_vault, "fin-06")
+        result = verify_run(tmp_vault, "fin-06")
+        names = {c["name"] for c in result["checks"]}
+        assert "quote-integrity" in names
+        assert "retracted-citations" in names
+
+
 class TestCiteCheckerAgentInstall:
     def test_agent_installs(self, tmp_vault):
         from hyperresearch.core.hooks import _install_cite_checker_agent


### PR DESCRIPTION
## What this is

The first premier bench run (Q62) shipped past both quality gates because they were prose instructions, not code: `run verify` was never invoked (a 25,647-word report shipped against a 16K target), and when lint flagged 24 hallucinated/mangled quotes the orchestrator classified them as "false positives" and shipped anyway. This PR makes the gate mechanical.

## Changes

- **`hpr run finish <tag>`**: the terminal ship gate and the ONLY path to manifest status `done`. Verify passes -> `done`; fails -> `blocked (verify)`, exit 1, verdict recorded in the manifest either way.
- **`verify_run` folds in the blocking content lints** (`quote-integrity`, `retracted-citations`), so one command carries the whole verdict and no rule can be re-run separately and argued with.
- **Router final gate rewritten** around `run finish`: no-override language, a per-check fix playbook, a bounded 3-round fix loop, and invariant 14 (a run is complete only when `finish` reports `passed: true`).
- **Length enforcement upstream**: step 11 gets a mechanical word-count check with one permitted synthesizer compression respawn (the old text forbade re-spawning, leaving big overages no legal fix). The synthesizer's word-target table now renders from the profile; it was hardcoded to full-gear numbers, so premier's 8-16K ceiling never reached the prompt.
- **Polish auditor** strips quotation marks from non-verbatim rhetorical framing before the gate sees them.

## Tests

512 passing (6 new: block on hallucinated quote, block on over-length, fix-then-pass loop, CLI exit codes, content gates present in verify). Router golden regenerated; deviation logged in the test module docstring.
