### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-23
+
 ### Coverage before elegance: the synthesizer stops trading substance for prose
 
 A rerun of a comparison query scored below its own older baseline on comprehensiveness and insight, and reading both reports side by side showed why: same word count, spent differently. The humanization work (primers, calm citations, one committed thesis) had quietly taught the synthesizer to dissolve a systematic ten-axis comparison into an elegant narrative and to compress a fully developed quantitative mechanism down to a one-line mention. Cleaner to read, and worse on exactly the axes a "compare X, Y, Z" prompt is graded on. The prompts were conflating two different edits: cutting prose, which is right, and cutting substance, which is not.
@@ -100,6 +102,8 @@ Source quality becomes a persistent, queryable property instead of ephemeral pro
 - **Pipeline profiles** (`hyperresearch profile list/show/validate`). Every research-scale knob — source gates, fetcher fan-out, loci caps, depth budgets, draft counts, word targets, critic caps, per-agent models — lives in a named, validated profile. Built-in `full` and `light` reproduce the shipped V8 values exactly; users override keys or define new profiles (`[profile.dissertation] extends = "full"`) in config.toml.
 - **Skill/agent prompts are now templates rendered at install.** `hyperresearch install --profile <name>` renders the 17 skills and 15 agent prompts from the chosen profile (custom `<< >>` Jinja delimiters — prompt-native `{{...}}` placeholders and JSON braces pass through untouched). Rendered files carry a `rendered from profile "..."` provenance header after the frontmatter. Golden tests pin the `full`-profile render byte-for-byte against the pre-template prompts, so profile/template drift is a test failure, not a silent prompt change.
 - **Width-sweep consistency fix** (roadmap phase-0 WS5, pulled forward): the three contradictory full-tier source-target statements (40-100 / 40–80 / 55–80) are unified to the profile value (55–80); the light target (12–20 vs 15–25) and the tier-table fetchers-per-wave (8–12 vs 10–12) are likewise unified to the table/Wave-1 values.
+
+## [0.8.7] - 2026-07-18
 
 Community-fix release: five contributed PRs plus two maintainer follow-ups, closing #32, #33, #35, #37, and #39.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hyperresearch"
-version = "0.8.7"
+version = "0.9.0"
 description = "Claude Code harness for disciplined, adversarially-audited deep research with full provenance."
 readme = "README.md"
 license = "MIT"

--- a/src/hyperresearch/__init__.py
+++ b/src/hyperresearch/__init__.py
@@ -1,3 +1,3 @@
 """Hyperresearch — agent-driven research knowledge base."""
 
-__version__ = "0.8.7"
+__version__ = "0.9.0"


### PR DESCRIPTION
Cuts 0.9.0 from everything that piled up in Unreleased since 0.8.7:

- Coverage before elegance: the synthesizer stops trading substance for prose (#56)
- Run levers: auto-selected register, domain notes, inference depth (#54)
- Ship-gate enforcement via `run finish` (#49)
- Report register: pedagogy primers, calm citations, de-AI'd prose (#50)
- The 2.0 groundwork phases (profiles, source ranking, runs, browser lane, verification)

Bumps `pyproject.toml` and `__version__` to 0.9.0 and moves the Unreleased block into a dated `[0.9.0]` section.

One cleanup while I was in there: the `[0.8.7]` CHANGELOG section had been folded back under Unreleased by an earlier merge that dropped its header, so the file read as if 0.8.7 never shipped. Restored it in place. No content lost, just re-headered.

Tagging happens after this merges, which is what triggers the PyPI publish.
