### PR TITLE
release: v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-07-25
+
 ### Four silent-failure leaks closed (tags, FTS syntax, batch PDFs, cache-busting date)
 
 - **Tag filtering:** frontmatter tags are now lowercased before the alias lookup and before storage, matching the lowercase alias keys and the lowercasing `SearchFilters` does on the query side — `--tag llm` now finds notes tagged `LLM`, including through aliases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hyperresearch"
-version = "0.9.0"
+version = "0.9.1"
 description = "Claude Code harness for disciplined, adversarially-audited deep research with full provenance."
 readme = "README.md"
 license = "MIT"

--- a/src/hyperresearch/__init__.py
+++ b/src/hyperresearch/__init__.py
@@ -1,3 +1,3 @@
 """Hyperresearch — agent-driven research knowledge base."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"


### PR DESCRIPTION
Cuts 0.9.1 from the two PRs that landed after 0.9.0. Both are correctness/security work rather than features, so they're worth getting onto PyPI now instead of waiting for the next feature release.

- **Fetched note bodies wrapped as untrusted data (#51).** Bodies fetched from the web are served inside `<untrusted-source>` delimiters with a treat-as-data preamble on both `note show` and `search`, forged fence tags are neutralized, and the agent prompts gained an untrusted-content policy block.
- **Four silent-failure leaks closed (#52).** Tag filtering lowercases before the alias lookup, FTS strips stray quotes instead of erroring to zero results, batch PDF fetches fall back to the browser path instead of vanishing, and the vault CLAUDE.md blurb stopped busting the prompt cache daily.

Mechanical: bumps `pyproject.toml` and `__version__` to 0.9.1, dates the `[Unreleased]` block as `[0.9.1]`. No link ref added, matching how 0.7.0 onward were cut.

Verified locally before pushing (fork PRs don't get CI here): ruff clean, 591 passing, `python -m build` produces both artifacts, `twine check` passes on each, and the wheel carries `core/untrusted.py` with `Version: 0.9.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)