### PR TITLE
tests: reset the process-global render context between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,22 @@ import pytest
 from hyperresearch.core.vault import Vault
 
 
+@pytest.fixture(autouse=True)
+def _reset_render_state():
+    """Reset hooks' process-global render context between tests.
+
+    install_hooks() sets a module-global profile context that direct
+    _install_* calls reuse; without a reset, a test that installs with a
+    profile overlay (e.g. a haiku fetcher) poisons every later install
+    in the same process. Only bites when file order puts the overlay
+    test first, which is why the default alphabetical run never sees it.
+    """
+    from hyperresearch.core import hooks
+
+    yield
+    hooks._RENDER_STATE = None
+
+
 @pytest.fixture
 def tmp_vault(tmp_path: Path) -> Vault:
     """Create a temporary vault for testing."""


### PR DESCRIPTION
`install_hooks()` stores the rendered profile context in a module global (`hooks._RENDER_STATE`) so the individual `_install_*` helpers can reuse it. The tests call those helpers directly, relying on the lazy full-profile fallback. That fallback only fires when the global is unset, so any test that runs `install_hooks()` with a profile overlay leaks its context into every later direct `_install_*` call in the same process.

Concrete repro on main (file order matters):

```
pytest tests/test_core/test_prompt_golden.py tests/test_core/test_hooks.py
```

`test_haiku_fetcher_overlay_reaches_installed_agent` installs with `models = { fetcher = "haiku" }`; `test_install_fetcher_agent` then renders the fetcher agent from the leaked context and fails asserting `model: sonnet`. The default alphabetical collection order runs `test_hooks.py` first, which is the only reason the standard suite stays green. Any reordering (pytest-randomly, `--lf`, running a subset in a different order) can trip it.

Fix: an autouse fixture in `tests/conftest.py` that clears `hooks._RENDER_STATE` after each test, restoring the lazy default for the next one. Test-only change; no production code touched.

Found while merging v0.9.0 into a downstream fork, where a manual non-alphabetical pytest invocation tripped it. Full suite (554) plus ruff verified green on this branch against current main (`d3011f2`).